### PR TITLE
Adding bucket_key to the saved snapshot data so we can reuse the bucket upon bot starting and resuming where it left off

### DIFF
--- a/common/sql/nibbler.js
+++ b/common/sql/nibbler.js
@@ -86,8 +86,6 @@ module.exports = function(client, table, id, opts) {
 		log(`Starting.  Total: ${nibble.total}`);
 		//var hadRecentErrors = 0;
 		async.doWhilst(done => {
-				let sql;
-				let params;
 				client.nibble(table, id, nibble.start, nibble.min, nibble.max, nibble.limit, opts.reverse, (err, result) => {
 					if (err) {
 						return done(err);

--- a/postgres/index.js
+++ b/postgres/index.js
@@ -3,6 +3,10 @@ const connect = require("./lib/connect.js");
 const sqlLoader = require("leo-connector-common/sql/loader");
 const sqlNibbler = require("leo-connector-common/sql/nibbler");
 const sqlSnapshotter = require("leo-connector-common/sql/snapshotter");
+const snapShotter = require("leo-connector-common/sql/snapshotter");
+
+const leo = require("leo-sdk");
+const ls = leo.streams;
 
 const binlogReader = require("./lib/binlogreader.js");
 
@@ -15,6 +19,20 @@ module.exports = {
 	},
 	snapshot: function(config, table, id, domain) {
 		return sqlSnapshotter(connect(config), table, id, domain);
+	},
+	domainObjectLoader: function(bot_id, dbConfig, sql, domain, opts, callback) {
+		if (opts.snapshot) {
+			snapShotter(bot_id, connect(dbConfig), dbConfig.table, dbConfig.id, domain, {
+				event: opts.outQueue
+			}, callback);
+		} else {
+			let stream = leo.read(bot_id, opts.inQueue);
+			let stats = ls.stats(bot_id, opts.inQueue);
+			ls.pipe(stream, this.load(dbConfig, sql, domain), leo.load(bot_id, opts.outQueue || dbConfig.table), err => {
+				if (err) return callback(err);
+				return stats.checkpoint(callback);
+			});
+		}
 	},
 	streamChanges: binlogReader.stream
 };

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leo-connector-postgres",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 * Removed unused variables.
 * Added bucket_key for when we’re resuming snapshotting so the snapshot files will be put into the same bucket.
 * Added domainObjectLoader to postgres for use with snapshotting.