### PR TITLE
Added auto peer build for postgres, same as it's done for mysql

### DIFF
--- a/mysql/package.json
+++ b/mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-connector-mysql",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {
@@ -10,8 +10,8 @@
 	"license": "ISC",
 	"dependencies": {
 		"chai": "^4.1.2",
-		"leo-connector-common": "^1.1.0",
-		"leo-sdk": "^1.0.72",
+		"leo-connector-common": "^1.1.2",
+		"leo-sdk": "^1.0.74",
 		"mysql2": "^1.5.3"
 	},
 	"config": {

--- a/mysql/package.json
+++ b/mysql/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"chai": "^4.1.2",
 		"leo-connector-common": "^1.1.2",
-		"leo-sdk": "^1.0.74",
+		"leo-sdk": "^1.1.0",
 		"mysql2": "^1.5.3"
 	},
 	"config": {

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -13,7 +13,7 @@
 		"aws-sdk": "^2.213.1",
 		"fast-csv": "^2.4.1",
 		"leo-connector-common": "^1.1.2",
-		"leo-sdk": "^1.0.74",
+		"leo-sdk": "^1.1.0",
 		"pg": "^7.4.1",
 		"pg-copy-streams": "^1.2.0",
 		"pg-format": "^1.0.4",

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-connector-postgres",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "",
 	"main": "index.js",
 	"scripts": {
@@ -12,8 +12,8 @@
 	"dependencies": {
 		"aws-sdk": "^2.213.1",
 		"fast-csv": "^2.4.1",
-		"leo-connector-common": "^1.1.0",
-		"leo-sdk": "^1.0.72",
+		"leo-connector-common": "^1.1.2",
+		"leo-sdk": "^1.0.74",
 		"pg": "^7.4.1",
 		"pg-copy-streams": "^1.2.0",
 		"pg-format": "^1.0.4",
@@ -25,5 +25,15 @@
 		"eslint": "^4.19.1",
 		"mocha": "^5.0.5",
 		"sinon": "^4.4.8"
+	},
+	"config": {
+		"leo": {
+			"build": {
+				"include": [
+					"pg",
+					"pg-format"
+				]
+			}
+		}
 	}
 }

--- a/sqlserver/package.json
+++ b/sqlserver/package.json
@@ -10,7 +10,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"leo-connector-common": "^1.1.0",
-		"leo-sdk": "^1.0.72",
+		"leo-sdk": "^1.1.0",
 		"mssql": "^4.1.0",
 		"uuid": "^3.2.1"
 	},


### PR DESCRIPTION
Updated version numbers.
Mysql added a new feature, so updating the middle version number. We still need to add the bot to postgres and sqlserver.