### PR TITLE
Need single quotes for when comparison

### DIFF
--- a/postgres/lib/checksum.js
+++ b/postgres/lib/checksum.js
@@ -279,7 +279,7 @@ module.exports = function(connection, fieldsTable) {
 				where ${event.settings.id_column} __IDCOLUMNLIMIT__`;
 			}
 
-			connection.query(event.settings.sql.replace('__IDCOLUMNLIMIT__', ` between 1 and 0 LIMIT 0`), (err, rows, fields) => {
+			connection.query(event.settings.sql.replace('__IDCOLUMNLIMIT__', ` between '1' and '0' LIMIT 0`), (err, rows, fields) => {
 				if (err) {
 					reject(err);
 					return;


### PR DESCRIPTION
This comparison requires that the 1 and 0 be quoted in the event that the column is a varchar.  Otherwise, we get the error 

operator does not exist: character varying >= integer

you might need to make this change on redshift, sql server, and mysql connectors too, but I don't use any of those so I just at least want the postgres one fixed