### PR TITLE
common and mysql connectors

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-connector-common",
-	"version": "1.4.5",
+	"version": "1.5.0",
 	"description": "Common package for all Leo Platform database connectors",
 	"main": "index.js",
 	"directories": {},

--- a/common/sql/loader/lib.js
+++ b/common/sql/loader/lib.js
@@ -7,9 +7,11 @@ module.exports = {
 			let ids = [];
 			let tasks = [];
 			idlist.forEach(idthing => {
+				// array of ids
 				if (Array.isArray(idthing)) {
 					ids = ids.concat(idthing);
-				} else if (idthing && typeof idthing == "object") {
+				} else if (idthing && typeof idthing === "object") {
+					// idthing is an object with ids
 					if (idthing.ids && idthing.ids.length >= 1) {
 						tasks.push((done) => {
 							async.doWhilst((done) => {
@@ -49,7 +51,8 @@ module.exports = {
 							});
 						});
 					}
-				} else if (typeof idthing == "string") {
+				} else if (typeof idthing === "string") {
+					// idthing is a query string
 					tasks.push((done) => {
 						sqlClient.query(idthing, (err, results, fields) => {
 							if (!err && results.length) {

--- a/mysql/package.json
+++ b/mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-connector-mysql",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "A MySQL database connector for use with Leo Platform",
 	"repository": {
 		"type": "git",
@@ -18,7 +18,7 @@
 	"homepage": "https://github.com/LeoPlatform/connectors#readme",
 	"dependencies": {
 		"chai": "^4.1.2",
-		"leo-connector-common": "^1.4.0",
+		"leo-connector-common": "^1.5.0",
 		"leo-logger": "^1.0.0",
 		"leo-sdk": "^2.0.1",
 		"mysql2": "^1.6.1",


### PR DESCRIPTION
 * Added omitTable to the MySQL listener and botHelper.
 * Added includeSchema to only work from selected databases (not all databases just yet on the domain object).
 * Added ability to just specify tables and just assume a primary key on the botHelper.
 * Added ability to process changes with or without a database specified.
 * Removed one-to-one join code.