### PR TITLE
change to allow empty results from tableIdTranslation lookups for dom…

### DIFF
--- a/common/dol.js
+++ b/common/dol.js
@@ -724,7 +724,7 @@ module.exports = class Dol {
 	}
 
 	processResults(err, rows, done) {
-		if (rows && Object.keys(rows[0]).length > 1) {
+		if (rows && rows.length >= 1 && Object.keys(rows[0]).length > 1) {
 			return done(err, rows);
 		}
 


### PR DESCRIPTION
…ain object building.

We have our shipments domain object that looks for updates to the user table and updates the shipment domain object when the user is updated.  When a user is changed that has never created a shipment, this returns an empty array for the value of rows.

This was erroring, but we need it to just continue without any updates in this case.