### PR TITLE
Unnecessary double filter on auditdate

### DIFF
--- a/postgres/lib/dwconnect.js
+++ b/postgres/lib/dwconnect.js
@@ -452,7 +452,7 @@ module.exports = function(config, columnConfig) {
                         FROM ${table} t
                         ${joinTables.join("\n")}
                         where ${nk.map(id=>`dm.${id} = t.${id}`).join(' and ')}
-                            AND dm.${columnConfig._auditdate} = ${dwClient.auditdate} AND t.${columnConfig._auditdate} = ${dwClient.auditdate}
+                            AND dm.${columnConfig._auditdate} = ${dwClient.auditdate}
                     `, done);
 				} else {
 					done();


### PR DESCRIPTION
We don't need to filter on _auditdate on this update statement.  It is joining to itself, so there is no reason to filter on _auditdate twice.  Also, in our staging environment, this was causing queries to hang.