### PR TITLE
Multiple tables with different keys doesn't work. 

### DIFF
--- a/sqlserver/index.js
+++ b/sqlserver/index.js
@@ -90,8 +90,8 @@ class connector extends parent {
 						eid += opts.tables[tableName].map(field => r[field]).join('.');
 						payload = r;
 					} else {
-						eid += r[opts.tables[tableName]];
-						payload = r[opts.tables[tableName]];
+						eid += r[Object.keys(r)[0]];
+						payload = r[Object.keys(r)[0]];
 					}
 
 					obj.correlation_id.units++;


### PR DESCRIPTION
Union statement returns first column name for every table name returned.