### PR TITLE
En 875 serverless entity

### DIFF
--- a/entity-table/index.js
+++ b/entity-table/index.js
@@ -189,7 +189,7 @@ module.exports = {
 							eventPrefix = image.partition.split(/-/)[0];
 						}
 					}
-					data.id = `${resourcePrefix}${options.botSuffix || ""}`;
+					data.id = `${eventPrefix}${options.botSuffix || ""}`;
 					data.event = `${eventPrefix}${resourceSuffix}`;
 					let sanitizedSrc = data.correlation_id.source.replace(/-[A-Z0-9]{12,}$/, "");
 					let system = opts.system || `system:dynamodb.${sanitizedSrc}.${eventPrefix}`;

--- a/entity-table/index.js
+++ b/entity-table/index.js
@@ -212,7 +212,7 @@ module.exports = {
 			return pfx ? pfx.trim().replace(/-$/, "").trim() : "";
 		}
 	},
-	tableProcessor: function(event, context, callback) {
+	tableProcessor: function(event, context, callback) {	// old function for supporting old way before we had tableOldNewProcessor
 		this.tableOldNewProcessor({
 		    botSuffix: "_entity_changes",
 		    defaultQueue: "Unknown",

--- a/entity-table/index.js
+++ b/entity-table/index.js
@@ -192,8 +192,8 @@ module.exports = {
 					data.id = `${eventPrefix}${options.botSuffix || ""}`;
 					data.event = `${eventPrefix}${resourceSuffix}`;
 					let sanitizedSrc = data.correlation_id.source.replace(/-[A-Z0-9]{12,}$/, "");
-					let system = opts.system || `system:dynamodb.${sanitizedSrc}.${eventPrefix}`;
-					data.correlation_id.source = system;
+					let source = opts.abbreviatedSystem ? `system:ddb-${sanitizedSrc}-${eventPrefix}` : `system:dynamodb.${sanitizedSrc}.${eventPrefix}`;
+					data.correlation_id.source = source;
 
 					let stream = getStream(data.id);
 					stream.write(data) ? done() : stream.once("drain", () => done());

--- a/entity-table/index.js
+++ b/entity-table/index.js
@@ -116,7 +116,8 @@ module.exports = {
 							return reject(err);
 						}
 						if (statsData.units > 0) {
-							leo.bot.checkpoint(botId, `system:dynamodb.${table.replace(/-[A-Z0-9]{12,}$/, "")}.${entity}`, {
+							let system = opts.system || `system:dynamodb.${table.replace(/-[A-Z0-9]{12,}$/, "")}.${entity}`;
+							leo.bot.checkpoint(botId, system, {
 								type: "write",
 								eid: statsData.eid,
 								records: statsData.units,
@@ -191,7 +192,8 @@ module.exports = {
 					data.id = `${resourcePrefix}${options.botSuffix || ""}`;
 					data.event = `${eventPrefix}${resourceSuffix}`;
 					let sanitizedSrc = data.correlation_id.source.replace(/-[A-Z0-9]{12,}$/, "");
-					data.correlation_id.source = `system:dynamodb.${sanitizedSrc}.${eventPrefix}`;
+					let system = opts.system || `system:dynamodb.${sanitizedSrc}.${eventPrefix}`;
+					data.correlation_id.source = system;
 
 					let stream = getStream(data.id);
 					stream.write(data) ? done() : stream.once("drain", () => done());


### PR DESCRIPTION
- Changed old tableProcessor function to point at tableOldNewProcessor
- Allowed for passing in custom "system" to loadFromQueue and tableOldNewProcessor functions so we don't have to conform to fixed naming standard (system:dynamodb.table.entity)