### PR TITLE
Enhanced getQueryIdFunction for mongo _id + id

### DIFF
--- a/mongo/lib/checksum.js
+++ b/mongo/lib/checksum.js
@@ -17,12 +17,14 @@ module.exports = () => {
         return obj[settings.id_column];
     };
     const getQueryIdFunction = (settings) => {
+        let fn = (a) => a;
         if (settings.extractId) {
-            return eval(`(${settings.extractId})`);
-        } else if (settings.id_column == "_id") {
-            return (v) => new ObjectID(v);
+            fn = eval(`(${settings.extractId})`);
+        } 
+        if (settings.id_column == "_id") {
+            return (v) => new ObjectID(fn(v));
         } else {
-            return (v) => v;
+            return fn;
         }
     };
     const getWhereObject = (settings) => {


### PR DESCRIPTION
When you pass in extract function, it wouldn't allow you to do a Mongo _id (which needs ObjectID) + another id.  We need to be able to do this for f_invoice_item.