### PR TITLE
Made the fields attribute able to be undefined

### DIFF
--- a/elasticsearch/lib/connect.js
+++ b/elasticsearch/lib/connect.js
@@ -78,7 +78,7 @@ module.exports = function(config) {
 
 				client.bulk({
 					body: body,
-					fields: false,
+					fields: settings.fieldsUndefined ? undefined : false,
 					_source: false
 				}, function(err, data) {
 					if (err || data.errors) {


### PR DESCRIPTION
Since Elasticsearch 7.1 deprecates the fields attribute, we need a way to set it to undefined here.