### PR TITLE
Downgrade version of Elasticsearch

### DIFF
--- a/elasticsearch/package.json
+++ b/elasticsearch/package.json
@@ -9,7 +9,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"elasticsearch": "16.5.0",
+		"elasticsearch": "16.1.1",
 		"http-aws-es": "6.0.0",
 		"leo-connector-common": "^3.0.8",
 		"leo-logger": "^1.0.1",


### PR DESCRIPTION
Elasticsearch 16.5 breaks on client.get since it is designed for Elasticsearch 7 server - it no longer supports passing in a type.