### PR TITLE
Set apiVersion

### DIFF
--- a/elasticsearch/lib/connect.js
+++ b/elasticsearch/lib/connect.js
@@ -45,6 +45,7 @@ module.exports = function (clientConfigHost, region) {
 		}
 
 		m = elasticsearch.Client(Object.assign({
+			apiVersion: '7.0',
 			connectionClass: require('http-aws-es'),
 			timeout: '1000000m',
 		}, config));


### PR DESCRIPTION
client.get doesn't work on Elasticsearch 6 clusters because it no longer supports type by default.  apiVersion 7.1 and below support it.