### PR TITLE
Connect to admin database and then switch to local

### DIFF
--- a/mongo/lib/tail.js
+++ b/mongo/lib/tail.js
@@ -49,7 +49,7 @@ module.exports = {
 		function connect() {
 			clearTimeout(delayedTimeout);
 			clearTimeout(sendTimeout);
-			let localDatabaseConnectString = `mongodb://${settings.server}/local?readPreference=secondary&slaveOk=true`;
+			let localDatabaseConnectString = `mongodb://${settings.server}/admin?readPreference=secondary&slaveOk=true`;
 			let databaseConnectString = `mongodb://${settings.server}/${settings.db}?readPreference=secondary&slaveOk=true`;
 			Promise.all([
 				MongoClient.connect(localDatabaseConnectString, { useNewUrlParser: true }),
@@ -57,7 +57,7 @@ module.exports = {
 			]).then(mongoClientArray => {
 				attempts = 0;
 				pass.mongoClientArray = mongoClientArray;
-				let localdb = mongoClientArray[0].db();
+				let localdb = mongoClientArray[0].db('local');
 				let db = pass.database = mongoClientArray[1].db();
 				let collection = pass.collection = db.collection(settings.collection);
 


### PR DESCRIPTION
In MongoDB 4.2, we aren't able to connect to the local database directly, so we need to connect to the admin database, and then switch over to the local database.