### PR TITLE
Update the record auditdate when updating _deleted

### DIFF
--- a/postgres/lib/dwconnect.js
+++ b/postgres/lib/dwconnect.js
@@ -44,7 +44,7 @@ module.exports = function (config, columnConfig) {
 		function tryFlushDelete (done, force = false) {
 			if (force || toDeleteCount >= 1000) {
 				let deleteTasks = Object.keys(toDelete).map(col => {
-					return deleteDone => client.query(`update ${qualifiedTable} set ${field} = ${value} where ${col} in (${toDelete[col].join(',')}) ${where}`, deleteDone);
+					return deleteDone => client.query(`update ${qualifiedTable} set ${field} = ${value}, ${columnConfig._auditdate} = ${dwClient.auditdate} where ${col} in (${toDelete[col].join(',')}) ${where}`, deleteDone);
 				});
 				async.parallelLimit(deleteTasks, 1, (err) => {
 					if (!err) {


### PR DESCRIPTION
This is leading to sync errors because the sync system doesn't know these records have been updated recently