### PR TITLE
fix: clear schema cache after ALTER TABLE ADD COLUMN

### DIFF
--- a/datalake/lib/dwconnect.js
+++ b/datalake/lib/dwconnect.js
@@ -121,7 +121,10 @@ module.exports = function(dbconfig, options) {
 							[], addDone
 						);
 					});
-					async.series(addTasks, done);
+					async.series(addTasks, (err) => {
+						if (!err) client.clearSchemaCache();
+						done(err);
+					});
 				} else {
 					done();
 				}

--- a/datalake/test/integration/schema_evolution.test.js
+++ b/datalake/test/integration/schema_evolution.test.js
@@ -66,7 +66,6 @@ describe('Schema evolution: add column mid-flight', function() {
 
 	it('loads 10 more rows with extra_col set; prior rows show null', async function() {
 		if (!dbconfig) return this.skip();
-		client.clearSchemaCache(); // pick up the new column for staging columnDefs
 		const extraRecords = [];
 		for (let i = 101; i <= 110; i++) {
 			extraRecords.push(Object.assign({}, makeRecords(i)[i - 1], {


### PR DESCRIPTION
## Summary
- `changeTableStructure()` now calls `clearSchemaCache()` after a successful `ALTER TABLE ADD COLUMN`, matching the existing behaviour on the `CREATE TABLE` path.
- Removes the `client.clearSchemaCache()` workaround from `schema_evolution.test.js` that compensated for the missing cache invalidation.

## Root cause
The schema cache was only cleared on table creation. A same-process import immediately after schema evolution would use stale `columnDefs`, causing newly added columns to be omitted from the staging CSV and land as null.

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm test` (unit) passes
- [ ] Integration test `schema_evolution.test.js` passes against Databricks dev workspace without the explicit `clearSchemaCache()` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted cache invalidation in schema evolution with an integration test proving the fix; no auth or data-model changes beyond correct column staging.
> 
> **Overview**
> **`changeTableStructure()`** now calls **`clearSchemaCache()`** after all **`ALTER TABLE ADD COLUMN`** steps succeed, aligning with the existing **CREATE TABLE** path.
> 
> This fixes same-process imports right after schema evolution: **`stageToS3`** was building **`columnDefs`** from a stale cache, so new columns were dropped from the staging CSV and showed up as null.
> 
> The integration test no longer calls **`client.clearSchemaCache()`** manually before the follow-up import; behavior is covered by the connector fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4100c9e88ffc65f01283bfd1a2914a3aef0c8cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->