### PR TITLE
fix: add .npmrc so plain npm ci resolves peer deps

### DIFF
--- a/datalake/.npmrc
+++ b/datalake/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- Adds `datalake/.npmrc` with `legacy-peer-deps=true` so `npm ci` works without needing the explicit flag.

## Root cause
`leo-connector-common` / `leo-sdk` peer dependency conflicts cause npm 7+ to fail on plain `npm ci`. The workaround (`--legacy-peer-deps`) was documented but not encoded in project config, breaking any CI pipeline or developer setup using the plain command.

## Test plan
- [ ] `npm ci` (no flags) succeeds in `datalake/`
- [ ] `npm run lint` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-time npm config only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds **`datalake/.npmrc`** with **`legacy-peer-deps=true`** so **`npm ci`** in `datalake/` succeeds without **`--legacy-peer-deps`**.
> 
> This encodes the existing workaround for **`leo-connector-common`** / **`leo-sdk`** peer conflicts on npm 7+, which previously broke CI and local installs that used the plain command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36bfa7d2f107707918f45d6c20d50006a152d916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->