### PR TITLE
fix: return pool slot from connect() release()

### DIFF
--- a/datalake/lib/connect.js
+++ b/datalake/lib/connect.js
@@ -179,13 +179,39 @@ module.exports = function(config) {
 
 		// ── Connection ────────────────────────────────────────────────────────
 		// connect() acquires a pooled session wrapper and returns it. Callers that
-		// need a raw session (e.g. the existing unit tests) can call this; the
-		// wrapper's release() returns it to the pool (no-op on the session itself).
+		// need a raw session can call this; the checkout's release() returns it to
+		// the pool, or destroys it if a connection-class error was seen during use.
 		connect: async (_opts) => {
 			await ensureConnected();
 			const wrapper = await pool.acquire();
 			return Object.assign({}, wrapper, {
-				release: () => pool.release(wrapper).catch(() => {}),
+				// Classify errors so connection failures mark the wrapper dead.
+				// Do NOT pool.destroy/release here — caller drives connection lifetime.
+				query: (sql, paramsOrCb, cbOrOpts, opts) => {
+					let params, cb;
+					if (typeof paramsOrCb === 'function') {
+						cb = paramsOrCb;
+						params = [];
+						opts = cbOrOpts;
+					} else {
+						params = paramsOrCb || [];
+						cb = cbOrOpts;
+					}
+					wrapper.query(sql, params, (err, rows, fields) => {
+						if (err && isConnectionError(err)) {
+							wrapper.dead = true;
+						}
+						cb(err, rows, fields);
+					}, opts);
+				},
+				// Destroy dead wrappers rather than returning broken sessions to the pool.
+				release: () => {
+					if (wrapper.dead) {
+						pool.destroy(wrapper).catch(() => {});
+					} else {
+						pool.release(wrapper).catch(() => {});
+					}
+				},
 			});
 		},
 

--- a/datalake/lib/connect.js
+++ b/datalake/lib/connect.js
@@ -183,7 +183,10 @@ module.exports = function(config) {
 		// wrapper's release() returns it to the pool (no-op on the session itself).
 		connect: async (_opts) => {
 			await ensureConnected();
-			return pool.acquire();
+			const wrapper = await pool.acquire();
+			return Object.assign({}, wrapper, {
+				release: () => pool.release(wrapper).catch(() => {}),
+			});
 		},
 
 		disconnect: async () => drainPool(),

--- a/datalake/test/unit/connect.test.js
+++ b/datalake/test/unit/connect.test.js
@@ -572,14 +572,20 @@ describe('connect.js', () => {
 	});
 
 	describe('connect() — acquires from pool', () => {
-		it('calls pool.acquire()', async () => {
+		it('calls pool.acquire() and returns a wrapper with working release()', async () => {
 			const wrapper = { dead: false, release: () => {} };
 			poolStub.acquire.resolves(wrapper);
 
 			const client = connectFactory({ host: 'h', path: '/p', token: 't', catalog: 'c', schema: 's' });
 			const conn = await client.connect();
 			expect(poolStub.acquire.calledOnce).to.be.true;
-			expect(conn).to.equal(wrapper);
+			// conn is a thin wrapper — not the raw pool resource — so release() works
+			expect(conn).to.not.equal(wrapper);
+			expect(conn.dead).to.equal(wrapper.dead);
+			// release() must call pool.release with the original wrapper reference
+			conn.release();
+			expect(poolStub.release.calledOnce).to.be.true;
+			expect(poolStub.release.firstCall.args[0]).to.equal(wrapper);
 		});
 	});
 

--- a/datalake/test/unit/connect.test.js
+++ b/datalake/test/unit/connect.test.js
@@ -573,7 +573,7 @@ describe('connect.js', () => {
 
 	describe('connect() — acquires from pool', () => {
 		it('calls pool.acquire() and returns a wrapper with working release()', async () => {
-			const wrapper = { dead: false, release: () => {} };
+			const wrapper = { dead: false, query: sinon.stub(), release: () => {} };
 			poolStub.acquire.resolves(wrapper);
 
 			const client = connectFactory({ host: 'h', path: '/p', token: 't', catalog: 'c', schema: 's' });
@@ -582,10 +582,53 @@ describe('connect.js', () => {
 			// conn is a thin wrapper — not the raw pool resource — so release() works
 			expect(conn).to.not.equal(wrapper);
 			expect(conn.dead).to.equal(wrapper.dead);
-			// release() must call pool.release with the original wrapper reference
+			// release() on a healthy wrapper calls pool.release with the original reference
 			conn.release();
 			expect(poolStub.release.calledOnce).to.be.true;
 			expect(poolStub.release.firstCall.args[0]).to.equal(wrapper);
+			expect(poolStub.destroy.called).to.be.false;
+		});
+
+		it('marks wrapper dead and calls pool.destroy on release() after a connection-class error', (done) => {
+			const wrapper = { dead: false, query: sinon.stub(), release: () => {} };
+			poolStub.acquire.resolves(wrapper);
+			// Simulate a connection-class error from the session query
+			const connErr = new Error('socket hang up');
+			wrapper.query.callsFake((_sql, _params, cb) => cb(connErr));
+
+			const client = connectFactory({ host: 'h', path: '/p', token: 't', catalog: 'c', schema: 's' });
+			client.connect().then(conn => {
+				conn.query('SELECT 1', [], (err) => {
+					expect(err).to.equal(connErr);
+					expect(wrapper.dead).to.be.true;
+					// release() must destroy rather than return the broken wrapper
+					conn.release();
+					expect(poolStub.destroy.calledOnce).to.be.true;
+					expect(poolStub.destroy.firstCall.args[0]).to.equal(wrapper);
+					expect(poolStub.release.called).to.be.false;
+					done();
+				});
+			}).catch(done);
+		});
+
+		it('calls pool.release (not destroy) on release() after a non-connection query error', (done) => {
+			const wrapper = { dead: false, query: sinon.stub(), release: () => {} };
+			poolStub.acquire.resolves(wrapper);
+			// Simulate a query-class error (syntax error — not a connection failure)
+			const queryErr = new Error('[Databricks][SQL] syntax error');
+			wrapper.query.callsFake((_sql, _params, cb) => cb(queryErr));
+
+			const client = connectFactory({ host: 'h', path: '/p', token: 't', catalog: 'c', schema: 's' });
+			client.connect().then(conn => {
+				conn.query('BAD SQL', [], (err) => {
+					expect(err).to.equal(queryErr);
+					expect(wrapper.dead).to.be.false;
+					conn.release();
+					expect(poolStub.release.calledOnce).to.be.true;
+					expect(poolStub.destroy.called).to.be.false;
+					done();
+				});
+			}).catch(done);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- `client.connect()` returns a checkout wrapper with a working `release()` that calls `pool.release(wrapper)` (or `pool.destroy(wrapper)` after a connection-class error).
- Checkout `query()` mirrors top-level `client.query()`: sets `wrapper.dead = true` via `isConnectionError` without destroying immediately — caller drives connection lifetime via `release()`.
- Internal `createSessionClient.release()` no-op unchanged — pool still owns session lifecycle.

## Root cause
`pool.acquire()` returns the raw pool resource whose `release()` is intentionally a no-op. Callers using the postgres-style `conn = await connect(); conn.release()` pattern leaked a pool slot until `end()`/`disconnect()`. Additionally, the checkout inherited the raw session `query()` which never set `wrapper.dead`, so `release()` could return a broken session to the pool after a transport error.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (207 passing), including:
  - healthy checkout: `conn.release()` calls `pool.release(wrapper)` with original reference
  - connection-class error in `conn.query()` → `conn.release()` calls `pool.destroy(wrapper)`
  - non-connection error → `conn.release()` still calls `pool.release(wrapper)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)