### PR TITLE
fix: add random suffix to S3 staging key to prevent same-table collision

### DIFF
--- a/datalake/lib/connect.js
+++ b/datalake/lib/connect.js
@@ -10,6 +10,7 @@ const csv = require('fast-csv');
 // `leo-streams` npm package is a lighter sibling without toS3; we don't import it.
 const ls = require('leo-sdk').streams;
 const naiveIsoNow = require('./audit_timestamp.js');
+const crypto = require('crypto');
 
 // ── Config helpers ────────────────────────────────────────────────────────────
 function clamp(val, min, max, defaultVal) {
@@ -478,16 +479,16 @@ function ensureStagingLocation(client, config) {
 // Pure: compute the per-call staging S3 path from (bucket, prefix, table,
 // auditdate). The caller owns the resulting identifier — same shape as
 // postgres' `qualifiedStagingTable`, just with an S3 file as the staging
-// artifact instead of a temp table. Two parallel importFact calls naturally
-// produce distinct paths (different `table`), so the identifier carries no
-// cross-call hazard.
+// artifact instead of a temp table. The random suffix ensures uniqueness
+// across concurrent same-table imports.
 function stagingS3Path(s3Bucket, s3Prefix, table, auditdate) {
 	if (!s3Bucket || !s3Prefix) {
 		throw new Error('stagingS3Path: s3Bucket/s3Prefix unresolved — call client.ensureStagingLocation() first');
 	}
 	const cleanAuditDate = String(auditdate || "'" + naiveIsoNow() + "'")
 		.replace(/'/g, '').replace(/:/g, '-');
-	const key = `${String(s3Prefix).replace(/\/$/, '')}/${table}/${cleanAuditDate}.csv`;
+	const uniqueSuffix = crypto.randomBytes(4).toString('hex');
+	const key = `${String(s3Prefix).replace(/\/$/, '')}/${table}/${cleanAuditDate}-${uniqueSuffix}.csv`;
 	return {
 		bucket: s3Bucket,
 		key,

--- a/datalake/test/unit/connect.test.js
+++ b/datalake/test/unit/connect.test.js
@@ -487,28 +487,37 @@ describe('connect.js', () => {
 		});
 
 		describe('stagingS3Path', () => {
-			it('builds {bucket, key, uri} deterministically from inputs', () => {
+			it('builds {bucket, key, uri} with correct structure and random suffix', () => {
 				const p = realConnect.stagingS3Path('bkt', 'prefix/sub', 'f_order', "'2026-03-15T14:30:00'");
 				expect(p.bucket).to.equal('bkt');
-				expect(p.key).to.equal('prefix/sub/f_order/2026-03-15T14-30-00.csv');
-				expect(p.uri).to.equal('s3://bkt/prefix/sub/f_order/2026-03-15T14-30-00.csv');
+				// key: {prefix}/{table}/{auditdate}-{8hex}.csv
+				expect(p.key).to.match(/^prefix\/sub\/f_order\/2026-03-15T14-30-00-[0-9a-f]{8}\.csv$/);
+				expect(p.uri).to.match(/^s3:\/\/bkt\/prefix\/sub\/f_order\/2026-03-15T14-30-00-[0-9a-f]{8}\.csv$/);
 			});
 
 			it('strips a trailing slash from the prefix', () => {
 				const p = realConnect.stagingS3Path('bkt', 'prefix/sub/', 't', "'2026-01-01T00:00:00'");
-				expect(p.key).to.equal('prefix/sub/t/2026-01-01T00-00-00.csv');
+				expect(p.key).to.match(/^prefix\/sub\/t\/2026-01-01T00-00-00-[0-9a-f]{8}\.csv$/);
 			});
 
 			it('strips surrounding single quotes and replaces colons in the auditdate', () => {
 				const p = realConnect.stagingS3Path('b', 'p', 't', "'2026-03-15T14:30:00.123Z'");
-				// colons → dashes; quotes stripped; rest preserved
-				expect(p.key).to.equal('p/t/2026-03-15T14-30-00.123Z.csv');
+				// colons → dashes; quotes stripped; rest preserved; random suffix appended
+				expect(p.key).to.match(/^p\/t\/2026-03-15T14-30-00\.123Z-[0-9a-f]{8}\.csv$/);
 			});
 
 			it('two parallel callers with different tables produce distinct paths', () => {
 				const auditdate = "'2026-03-15T14:30:00'";
 				const a = realConnect.stagingS3Path('b', 'p', 'f_order', auditdate);
 				const b = realConnect.stagingS3Path('b', 'p', 'f_order_item', auditdate);
+				expect(a.key).to.not.equal(b.key);
+				expect(a.uri).to.not.equal(b.uri);
+			});
+
+			it('two parallel callers with the same table produce distinct paths', () => {
+				const auditdate = "'2026-03-15T14:30:00'";
+				const a = realConnect.stagingS3Path('b', 'p', 'f_order', auditdate);
+				const b = realConnect.stagingS3Path('b', 'p', 'f_order', auditdate);
 				expect(a.key).to.not.equal(b.key);
 				expect(a.uri).to.not.equal(b.uri);
 			});


### PR DESCRIPTION
## Summary
- `stagingS3Path()` now appends `crypto.randomBytes(4).toString("hex")` to every staging key, making paths unique per call regardless of timing.
- Corrects an incorrect comment that claimed same-table concurrency was safe.

## Root cause
The staging key was `{prefix}/{table}/{auditdate-to-second}.csv`. Two `importFact` calls for the same table within the same second produced the same S3 key. The second write overwrote the first, corrupting the staging input before the MERGE ran against it.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (100 passing; 2 pre-existing smoke-test failures are a sandbox restriction on writing to `/tmp/leo_dw_*`, unrelated to this change)
- [x] Added new test: "two parallel callers with the same table produce distinct paths"
- [x] Existing key-format assertions updated to regex match to accommodate the `-{8hex}` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the staging object key used before MERGE, which is on the critical import path, but the scope is small and the fix directly prevents concurrent same-table corruption.
> 
> **Overview**
> Fixes a race where concurrent **`importFact`** runs for the **same table** within the same second could share one staging S3 key (`{prefix}/{table}/{auditdate}.csv`), so the later upload overwrote the first and corrupted MERGE input.
> 
> **`stagingS3Path()`** now appends an 8-character hex suffix from **`crypto.randomBytes(4)`** to each key (`…-{suffix}.csv`), so every call gets a unique path even when table and audit date match. The comment above the helper is updated to reflect that uniqueness no longer relies on different tables or timing.
> 
> Unit tests for **`stagingS3Path`** now assert the new key shape with regexes and add coverage that two calls with the **same** table and audit date produce different keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068770b0c3c54272445abedec09f5ebf62b62818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->