### PR TITLE
refactor(datalake): remove clusterKey apparatus; unconditional CLUSTER BY AUTO

### DIFF
--- a/datalake/CLAUDE.md
+++ b/datalake/CLAUDE.md
@@ -11,7 +11,6 @@ This connector handles ingestion of retailer platform event data from RStreams q
 - **`dw_fields` JSON** — schema definition driving field mapping, types, natural keys (`nk`), surrogate keys (`sk`), and grouping. Stored in DynamoDB `${Stage}DW-Fields`; source of truth is the JSON files in each producer repo.
 - **`identifier`** — table name (e.g., `d_order`, `f_order_item`); `d_` prefix = dimension (one row per entity), `f_` prefix = fact (one row per event/activity)
 - **`groups`** — queue routing (e.g., `"dim"`, `"quantity"`); determines which loader group processes this table
-- **`clusterKey`** — optional field for Databricks physical layout hint (`CLUSTER BY`); no effect on Redshift by default (see Coding Rules)
 - **Surrogate keys** — FarmFingerprint64 hashes of the natural key, computed in Node.js via `farmhash-modern` and written into the staging CSV
 - **ETL pattern** (transformation before load): RStreams enrichments (change detection e.g. item-old-new → modified-product, record shaping e.g. modified-product → dimension) feed into offload (staging records to S3, mounting as a relation in Databricks, merging into live tables via DML MERGE)
 
@@ -88,7 +87,6 @@ The publishing/offload path does **not** go through `leo-connector-redshift`. Th
 When porting a function from `../postgres/`, **preserve every branch** in the original — don't silently flatten conditional logic to "simplify" the Databricks version. The bugs from doing that are exactly the kind that pass unit tests, slip past code review, and corrupt data at runtime months later. Concrete patterns to watch for:
 
 - **Dim vs fact branching.** Many postgres helpers gate behavior on `definition.isDimension` — e.g., `createTable` adds `_deleted` only for facts and `_startdate`/`_enddate`/`_current` only for dims. Mirror the branch; don't unconditionally apply one side's columns.
-- **Type-aware literal rendering.** `naturalKeyFilter` (and similar MIN/MAX bound literals) branches on the column's type — numeric columns render unquoted, string/timestamp quoted. Always quoting works in the happy path and produces silently wrong MERGE predicates when the column is numeric. Look up the column type from `describeTable` results.
 - **Configuration gates.** Postgres often gates a feature on `config.hashedSurrogateKeys`, `config.version`, etc. If the datalake side only supports one branch today, keep the conditional and `throw` (or no-op) the unsupported branch — don't delete it. Future contributors need to see the shape.
 - **Validate with a postgres-side grep, not the unit tests.** The unit-test fixtures in this repo were written alongside the port and can encode the same flattening bug — a passing test proves consistency with the test, not with the postgres source. When in doubt, `grep -n "<helper>" ../postgres/lib/dwconnect.js` and read the surrounding 30–50 lines.
 
@@ -107,7 +105,6 @@ Separately: some review-flagged patterns *should* match postgres and were kept o
 **Never:**
 - Release changes that impact the running Redshift pipeline as side effects. The publishing-path code (`../postgres/` — especially `lib/dwconnect.js` — plus `../common/datawarehouse/`, `../../general/lib/offload_to_redshift.js`, and the offload bots) may be refactored or extended (e.g., to enable shared patterns), but all changes must be backwards-compatible and safe by default — new functionality disabled unless explicitly enabled. `../redshift/` is consumer-only (used by `report/`) and is not on the publishing path. The Redshift pipeline must remain independently deployable and unaffected by what is or isn't complete on the Databricks side.
 - Use Redshift-specific SQL syntax in new code (`GETDATE()`, `TOP N`, `DISTKEY`/`SORTKEY` in DDL, `FARMFINGERPRINT64()`)
-- Add `clusterKey` behavior that affects Redshift — `clusterKey` must have no effect on Redshift by default (see below)
 - Add npm dependencies without asking first
 - Write SQL stored procedures
 - Commit credentials or Databricks tokens
@@ -115,7 +112,6 @@ Separately: some review-flagged patterns *should* match postgres and were kept o
 
 **Ask before:**
 - Adding a new top-level field to dw_fields (coordinate with DPLAT-442 / John Cronin — same field, same DynamoDB record; must be safe for the Redshift loader to silently ignore)
-- Enabling `clusterKey` as a Redshift SORTKEY override (disabled by default; requires explicit decision)
 - Changing staging or merge semantics in a way that would require any Redshift-side change to remain safe
 - Changing how surrogate keys are computed (output must remain identical to `FARMFINGERPRINT64()`)
 
@@ -127,9 +123,6 @@ The Redshift pipeline (`general/`, `offload_to_redshift.js`, `leo-connector-post
 - The datalake connector is a new package — it does not replace or wrap the Redshift connector; both exist independently
 - Datalake-side bots are new Lambda functions alongside (not replacing) the existing Redshift loader bots
 - Any code merged to `main` that touches shared config must leave the Redshift pipeline in a valid, deployable state
-
-**`clusterKey` field — Databricks only by default:**
-`clusterKey` in dw_fields drives Databricks `CLUSTER BY` for liquid clustering. The Redshift connector ignores it entirely (unknown fields are silently ignored by the DynamoDB scan). The option to also use it as a Redshift SORTKEY override may be implemented but **must be off by default** and gated behind an explicit configuration flag — never activated as a side effect of adding the field.
 
 ## Timestamp handling — preserving legacy no-TZ semantics
 

--- a/datalake/docs/BUILD_PLAN.md
+++ b/datalake/docs/BUILD_PLAN.md
@@ -106,28 +106,14 @@ Lock separator + null-rendering against the Redshift `FARMFINGERPRINT64()` conve
     | `decimal` (no precision) | `DECIMAL(18,0)` | **Explicit — match Redshift's default. Do NOT rely on Databricks' default of `DECIMAL(10,0)`.** |
     | `decimal(p,s)` | `DECIMAL(p,s)` | Pass through verbatim |
 
-    Always append `_auditdate TIMESTAMP_NTZ`, `_deleted BOOLEAN`. If `clusterKey`, append `CLUSTER BY (clusterKey)`. All identifiers emitted via `client.escapeId` (lowercase + backtick-quoted, per Step 3).
+    Always append `_auditdate TIMESTAMP_NTZ`, `_deleted BOOLEAN`, and `CLUSTER BY AUTO` (Databricks chooses clustering columns from observed query patterns via Predictive Optimization). All identifiers emitted via `client.escapeId` (lowercase + backtick-quoted, per Step 3).
   - `alterAddColumn(...)`, `alterColumnType(...)` (Databricks only widens; throw on narrowing).
-  - `mergeFact(target, staging, nks, columnConfig, naturalKeyFilter)` → `MERGE INTO … USING … ON <nk match> [AND target.<clusterKey> >= <naturalKeyFilter>] WHEN MATCHED THEN UPDATE SET … WHEN NOT MATCHED THEN INSERT …`. UPDATE sets each data column to `COALESCE(staging.x, target.x)`, `_deleted=false`, `_auditdate=<auditdate>`.
+  - `mergeFact(target, staging, nks, columnConfig, escapeId)` → `MERGE INTO … USING … ON <nk match> WHEN MATCHED THEN UPDATE SET … WHEN NOT MATCHED THEN INSERT …`. UPDATE sets each data column to `COALESCE(staging.x, target.x)`, `_deleted=false`, `_auditdate=<auditdate>`.
 
-  **`clusterKey` has two paired purposes** (per [Configuration Migration Analysis](https://www.notion.so/351e0f2aafae8128b7baed05f6a5adbc); coordinate field-name with DPLAT-442 / John Cronin):
-  1. **Physical layout** — `CLUSTER BY (clusterKey)` in `createTable` (already covered above).
-  2. **MERGE pruning** — `dwconnect.importFact` computes `MIN(clusterKey)` across the staged batch and passes it to `mergeFact` as `naturalKeyFilter`. The added predicate `AND target.<clusterKey> >= <min>` lets Delta skip files (and Redshift skip blocks) whose max for that column falls below the batch's min. Without this, MERGE scans the entire target.
+  **Physical layout — `CLUSTER BY AUTO`:** Every table is created with `CLUSTER BY AUTO`. With Predictive Optimization enabled on the catalog and a recent DBR / serverless SQL Warehouse, Databricks chooses clustering columns from observed query patterns — for MERGE-heavy connector workloads this converges on the natural key without any human hint. Existing tables created with explicit `CLUSTER BY` should be migrated via `ALTER TABLE … CLUSTER BY AUTO` (one-time DDL from a notebook).
 
-  **"Meaningful ordering within a batch" — what it means in practice:** the pruning helps only when the staged batch's clusterKey values cluster in a *narrow range high in the table's history*. Two things have to be true:
-  - **Density** — values within one batch span a small fraction of the table's overall range (otherwise `MIN` ≈ table min, and the filter prunes nothing).
-  - **Time-correlation with arrival** — newer events have higher clusterKey values, and batches arrive roughly in time order. Then `MIN(batch)` is far above the table's min and skips most historical files.
-
-  Examples:
-  - ✅ `order_id` on `f_order_item` (auto-increment BIGINT): a batch of recent order events sits in a narrow high range; prunes nearly all historical files.
-  - ✅ Event-time column on an append-only fact (e.g., the activity-timestamp column on `f_order_item_activity` — confirm exact column name in the table's `dw_fields` before using): same logic.
-  - ❌ `account_id`, `retailer_id`: any batch touches many accounts; `MIN` is small and stable; no pruning value.
-  - ❌ Categorical columns (status, country_code): no monotonic growth.
-
-  **Fallback** when `clusterKey` is absent (per memory): if the natural key itself has the same properties (single monotonic NK column like `order_id`), use `MIN(nk)`; otherwise emit no filter — never invent ordering.
-
-  `mergeFact` itself should treat `naturalKeyFilter` as opaque: if `null`/`undefined`, omit the extra predicate; otherwise inject it literally as `AND target.<clusterKeyCol> >= <value>`. The decision about *whether* to compute the filter lives in `dwconnect.importFact`, keeping `sql.js` pure.
-**Done when:** Snapshot tests cover createTable on `d_order.json`, alterAddColumn, mergeFact on an `f_*` table (with and without `naturalKeyFilter`), every row of the type-mapping table above (`varchar(n)`→`STRING`, `timestamp`→`TIMESTAMP_NTZ`, `timestamptz`→`TIMESTAMP`, `decimal` no-precision→`DECIMAL(18,0)`, `boolean`→`BOOLEAN`, etc.), identifier lowercasing via `escapeId`, `clusterKey` present/absent.
+  **MERGE scan — no manual pruning:** file-skipping on Delta tables happens via Photon's transaction-log column min/max statistics, driven by clustering. The manual `MIN(staging_col) >= target_col` predicate the postgres connector uses for Redshift SORTKEY-based block skipping is not needed (and was removed from this connector — see porting-decisions.md).
+**Done when:** Snapshot tests cover createTable on `d_order.json`, alterAddColumn, mergeFact on an `f_*` table, every row of the type-mapping table above (`varchar(n)`→`STRING`, `timestamp`→`TIMESTAMP_NTZ`, `timestamptz`→`TIMESTAMP`, `decimal` no-precision→`DECIMAL(18,0)`, `boolean`→`BOOLEAN`, etc.), identifier lowercasing via `escapeId`, `CLUSTER BY AUTO` present on all created tables.
 
 ### Step 6 — `lib/dwconnect.js`: factory + schema mutation
 Port the schema-mutation half of `connectors/postgres/lib/dwconnect.js` — on the `development` branch the relevant functions are scattered: `dropTempTables` at line 99, `importDimension` at 363, `insertMissingDimensions` at 679, `linkDimensions` at 742, `changeTableStructure` at 848, `createTable` at 915 (file is 1284 lines total):
@@ -255,7 +241,6 @@ Two complementary checks must both pass before DoD is satisfied:
 **Table coverage set is TBD — do not invent.** The script asserts equivalence on a list of tables drawn from what the captured fixture populates. Lock the list before running; minimum criteria:
 - ≥1 `d_*` and ≥1 `f_*` (dim and fact code paths exercised)
 - Type coverage across `varchar(n)→STRING`, `timestamp→TIMESTAMP_NTZ`, integer/bigint, boolean
-- ≥1 fact with a `clusterKey` set, so the `naturalKeyFilter` MERGE-pruning path (Step 5) is actually exercised — otherwise that path is silently untested
 - Mix of single-column and composite natural keys
 - Must be a subset of tables the captured `dim`-queue fixture actually populates
 

--- a/datalake/docs/NEXT_WORK_LIST.md
+++ b/datalake/docs/NEXT_WORK_LIST.md
@@ -18,7 +18,7 @@ Items are tagged **[Bug]** (correctness regression vs postgres), **[Gap]** (BUIL
 |---|---|---|---|
 | Staging artifact | `staging_<table>` real table | S3 file, inlined via `read_files()` in MERGE | Each pooled session can serve any query; a session-scoped temp view from one acquire isn't guaranteed to live across the MIN+MERGE pair |
 | UPSERT mechanism | `UPDATE prev FROM staging` + `INSERT WHERE NOT EXISTS` | `MERGE INTO ... WHEN MATCHED ... WHEN NOT MATCHED INSERT` | Delta supports atomic MERGE; Redshift doesn't |
-| `naturalKeyFilter` placement | WHERE clauses on `prev` joins / DELETE | MERGE `ON` clause `target.<clusterKey> >= <filter>` | Forced by MERGE mechanism |
+| `naturalKeyFilter` placement | WHERE clauses on `prev` joins / DELETE | Not used — Redshift block-skipping via SORTKEY has no equivalent; Delta file-skipping is driven by `CLUSTER BY AUTO` + Photon column stats | Databricks Photon handles this automatically |
 | `escapeId` casing | preserves case (`"Name"`) | lowercases (`` `name` ``) | Intentional lowercase-everywhere convention ([CLAUDE.md](../CLAUDE.md)); BUILD_PLAN Step 3 open question #7 |
 | Staging identifier | `qualifiedStagingTable = "${stageSchema}.${stageTablePrefix}_${table}"` | `stagingS3Path(s3Bucket, s3Prefix, table, auditdate)` | Different shape (URI vs schema-qualified name), same ownership pattern — caller owns and passes down |
 | Transactions | `BEGIN/COMMIT/ROLLBACK` around post-stage SQL | None | Pool sessions are independent acquires per query; multi-statement TX not viable in this model |
@@ -55,9 +55,9 @@ These are real and still present after `b62d3b8`. Worth addressing:
 
 - ~~**[Bug] `flushDeletes` post-retry error is swallowed.**~~ ✓ Fixed — `mergeCallback` hoisted before `withRetry(flushDeletes...)`; callback now takes `(flushErr)` and returns early. Unit-tested: `propagates a flushDeletes error and skips MERGE`.
 
-- ~~**[Bug] MIN query post-retry error is swallowed.**~~ ✓ Fixed — `qErr` now propagates via `mergeCallback`; error is logged at ERROR level before returning. Unit-tested: `propagates a MIN query error and skips MERGE`.
+- ~~**[Bug] `count` returned to the orchestrator is wrong.**~~ ✓ Fixed — `stagingCount` captured from a `SELECT CAST(COUNT(*) AS INT)` before the MERGE; `doMerge` simplified to `client.query(mergeSql, [], callback)`. Unit-tested. Integration-tested: `loads 100 records via importFact` now asserts `tableInfo.count === 100` and passes against live Databricks.
 
-- ~~**[Bug] `count` returned to the orchestrator is wrong.**~~ ✓ Fixed — `stagingCount` captured from MIN query's `cnt` (pruneCol path) or a separate `SELECT CAST(COUNT(*) AS INT)` (no-pruneCol path); `doMerge` simplified to `client.query(mergeSql, [], callback)`. Unit-tested on both paths. Integration-tested: `loads 100 records via importFact` now asserts `tableInfo.count === 100` and passes against live Databricks.
+- ~~**[Removed] `clusterKey` / `naturalKeyFilter` / `pruneCol` apparatus.**~~ ✓ Removed — the `clusterKey` dw_fields field, `MIN(clusterKey)` pruning query, `literalForType` helper, and all associated parameters dropped. Every table now declares `CLUSTER BY AUTO`; Databricks Photon handles file-skipping via transaction-log column statistics driven by clustering.
 
 - ~~**[Doc] Outdated `streamToTableFromS3` comment.**~~ ✓ Done — was actually in [dwconnect.js:207-209](../lib/dwconnect.js#L207-L209), not connect.js. Updated the rationale to "Sessions are pooled, so the MIN and MERGE queries may run on different acquires — a session-scoped temp view from one acquire is not guaranteed visible to the next. Inlining avoids that."
 

--- a/datalake/docs/NEXT_WORK_LIST.md
+++ b/datalake/docs/NEXT_WORK_LIST.md
@@ -42,7 +42,7 @@ Closed list of items deliberately left matching postgres. Don't re-flag without 
 
 - `flushDeletes` IN-list via string interpolation
 - `alterColumnType` helper exists but is never called from `changeTableStructure`
-- `escapeValue` lowercases (dead code in datalake; OrderStream/Dsco convention if ever wired)
+- `escapeValue` lowercases (dead in datalake until `findAuditDate`/`exportChanges` read path is ported — see §2)
 - Schema cache invalidated only on `createTable`, not on `ADD COLUMN`
 - `npm` scripts use shell globs
 - `dwClient = client` module-scope alias
@@ -100,6 +100,9 @@ All needed before the Step 9 CI workflows can authenticate.
 
 ### [Gap] Open question #6 follow-up — `READ_FILES` grant
 External Location `datalake-dev-external-location` exists (`infra-iac-databricks/data-platform/main.tf:263`) and covers the staging bucket. The `[dev-cup]` SP currently works for local dev. For CI, either: (a) reuse the `dbt` SP (already has `READ_FILES`), or (b) add a new SP + grant in `infra-iac-databricks/`. Decision deferred.
+
+### [Gap] Read-side interface — `findAuditDate` and `exportChanges` not yet ported
+`connectors/postgres/lib/dwconnect.js` exposes `client.findAuditDate(table, cb)` and `client.exportChanges(table, fields, remoteAuditdate, opts, cb)`. These are used by leoDW / Query Explorer to read audit dates and export changed rows from the DW. The datalake connector must implement Databricks-dialect equivalents before those consumers can migrate off Redshift. `escapeValue` (lowercasing variant, currently dead in the datalake connector) will be needed when this is built.
 
 ### [Gap] BUILD_PLAN risk #4 — `offload_to_datalake.js` bot
 Without this bot in `general/`, nothing runs in production. The connector library is complete for fact tables; dim tables additionally need `importDimension` and `linkDimensions` (see §3 Dimension code paths). Shortest deployment path: write the bot, run it against `supplier-catalog-dim` first (fact-only queue), then add dim queue support once `importDimension` is implemented.

--- a/datalake/docs/porting-decisions.md
+++ b/datalake/docs/porting-decisions.md
@@ -23,7 +23,7 @@ The datalake connector is a fork of the postgres connector adapted for Databrick
 ### `escapeValue` lowercases string values
 - **Location:** `lib/connect.js` — `escapeValue` returns `"'" + value.toLowerCase() + "'"`
 - **Why kept:** Two reasons.
-  1. **Dead code in datalake.** The only postgres callsites are in `needsToProcess` / `dwAuditdate` audit-comparison helpers that have not been ported. `escapeValue` is currently unreachable from any datalake codepath. The companion `escapeValueNoToLower` is defined in `connect.js` and is part of the client interface; it is currently unused since the `literalForType` / `naturalKeyFilter` apparatus was removed (see NEXT_WORK_LIST.md).
+  1. **Dead code in datalake.** The only postgres callsites are in `findAuditDate` and `exportChanges` — consumer-side read helpers that export changed rows to downstream sync callers (leoDW / Query Explorer). Neither has been ported because the datalake connector is purely a write path. `escapeValue` is currently unreachable from any datalake codepath. The companion `escapeValueNoToLower` is defined in `connect.js` and is part of the client interface; it is currently unused since the `literalForType` / `naturalKeyFilter` apparatus was removed (see NEXT_WORK_LIST.md).
   2. **The lowercasing is an OrderStream/Dsco convention** (all string data is lowercased before storage), not a bug. If `escapeValue` is ever wired up, that convention has to be preserved for parity with what Redshift consumers expect.
 
 ### Schema cache invalidated only on `createTable`, not on `ADD COLUMN`

--- a/datalake/docs/porting-decisions.md
+++ b/datalake/docs/porting-decisions.md
@@ -23,7 +23,7 @@ The datalake connector is a fork of the postgres connector adapted for Databrick
 ### `escapeValue` lowercases string values
 - **Location:** `lib/connect.js` — `escapeValue` returns `"'" + value.toLowerCase() + "'"`
 - **Why kept:** Two reasons.
-  1. **Dead code in datalake.** The only postgres callsites are in `needsToProcess` / `dwAuditdate` audit-comparison helpers that have not been ported. `escapeValue` is currently unreachable from any datalake codepath. The companion `escapeValueNoToLower` is the one actually in use (audit-timestamp literals, `naturalKeyFilter` for non-numeric types).
+  1. **Dead code in datalake.** The only postgres callsites are in `needsToProcess` / `dwAuditdate` audit-comparison helpers that have not been ported. `escapeValue` is currently unreachable from any datalake codepath. The companion `escapeValueNoToLower` is defined in `connect.js` and is part of the client interface; it is currently unused since the `literalForType` / `naturalKeyFilter` apparatus was removed (see NEXT_WORK_LIST.md).
   2. **The lowercasing is an OrderStream/Dsco convention** (all string data is lowercased before storage), not a bug. If `escapeValue` is ever wired up, that convention has to be preserved for parity with what Redshift consumers expect.
 
 ### Schema cache invalidated only on `createTable`, not on `ADD COLUMN`

--- a/datalake/docs/porting-decisions.md
+++ b/datalake/docs/porting-decisions.md
@@ -23,7 +23,7 @@ The datalake connector is a fork of the postgres connector adapted for Databrick
 ### `escapeValue` lowercases string values
 - **Location:** `lib/connect.js` — `escapeValue` returns `"'" + value.toLowerCase() + "'"`
 - **Why kept:** Two reasons.
-  1. **Dead code in datalake.** The only postgres callsites are in `findAuditDate` and `exportChanges` — consumer-side read helpers that export changed rows to downstream sync callers (leoDW / Query Explorer). Neither has been ported because the datalake connector is purely a write path. `escapeValue` is currently unreachable from any datalake codepath. The companion `escapeValueNoToLower` is defined in `connect.js` and is part of the client interface; it is currently unused since the `literalForType` / `naturalKeyFilter` apparatus was removed (see NEXT_WORK_LIST.md).
+  1. **Incomplete — `findAuditDate` and `exportChanges` not yet ported.** These are the read-side interface (leoDW / Query Explorer reads audit dates and exports changed rows). They will need to be implemented in the datalake connector when those consumers migrate to Databricks. `escapeValue` is therefore dead today but will be needed when that read path is built.
   2. **The lowercasing is an OrderStream/Dsco convention** (all string data is lowercased before storage), not a bug. If `escapeValue` is ever wired up, that convention has to be preserved for parity with what Redshift consumers expect.
 
 ### Schema cache invalidated only on `createTable`, not on `ADD COLUMN`

--- a/datalake/lib/dwconnect.js
+++ b/datalake/lib/dwconnect.js
@@ -192,8 +192,10 @@ module.exports = function(dbconfig, options) {
 		const auditdate = dwClient.auditdate;
 		const auditdateValue = auditdate ? auditdate.replace(/'/g, '') : naiveIsoNow();
 
+		let stagingCount = 0;
 		const fkEnrich = buildFkEnrichers(tableDef && tableDef.structure, columnConfig);
 		const enrichFn = obj => {
+			stagingCount++;
 			if (skField) {
 				obj[skField] = fingerprint64(nks.map(k => obj[k]));
 			}
@@ -211,27 +213,13 @@ module.exports = function(dbconfig, options) {
 			const { stagingPath, stagingClause, allCols, fieldLookup } = staged;
 			const auditCols = new Set([auditCol, delCol, columnConfig._current, columnConfig._startdate, columnConfig._enddate, columnConfig._rescued_data]);
 			const dataCols = allCols.filter(c => !nks.includes(c) && !auditCols.has(c));
-			let stagingCount = 0;
 
-			// Count sourced from staging rows, not MERGE result (which returns metrics,
-			// not row count). Mirrors postgres's totalRecords = results[0].cnt.
 			const mergeCallback = (mergeErr) =>
 				cleanupStagedFile(dbconfig, stagingPath, mergeErr, mergeErr ? null : { count: stagingCount }, callback);
 
 			withRetry(done => flushDeletes(client, qualifiedTable, deleteRecords, ids, columnConfig, auditdate, fieldLookup, done), {}, (flushErr) => {
 				if (flushErr) return mergeCallback(flushErr);
-
-				const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-				withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
-					if (countErr) {
-						logger.error('COUNT query failed after retries, aborting importFact:', countErr);
-						return mergeCallback(countErr);
-					}
-					if (countResults && countResults[0]) {
-						stagingCount = countResults[0].cnt || 0;
-					}
-					withRetry(done => doMerge(sql.mergeFact, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
-				});
+				withRetry(done => doMerge(sql.mergeFact, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
 			});
 		});
 	};
@@ -277,8 +265,10 @@ module.exports = function(dbconfig, options) {
 		const auditdate = dwClient.auditdate;
 		const auditdateValue = auditdate ? auditdate.replace(/'/g, '') : naiveIsoNow();
 
+		let stagingCount = 0;
 		const fkEnrich = buildFkEnrichers(tableDef && tableDef.structure, columnConfig);
 		const enrichFn = obj => {
+			if (!obj.__leo_delete__) stagingCount++;
 			if (skField) {
 				obj[skField] = fingerprint64(nks.map(k => obj[k]));
 			}
@@ -294,25 +284,13 @@ module.exports = function(dbconfig, options) {
 			// are managed by the MERGE SQL (sentinel values on INSERT; preserved on UPDATE).
 			const auditCols = new Set([auditCol, columnConfig._current, columnConfig._startdate, columnConfig._enddate, columnConfig._rescued_data]);
 			const dataCols = allCols.filter(c => !nks.includes(c) && !auditCols.has(c));
-			let stagingCount = 0;
 
 			const mergeCallback = (mergeErr) =>
 				cleanupStagedFile(dbconfig, stagingPath, mergeErr, mergeErr ? null : { count: stagingCount }, callback);
 
 			withRetry(done => flushDimDeletes(client, qualifiedTable, deleteRecords, columnConfig, auditdate, fieldLookup, done), {}, (flushErr) => {
 				if (flushErr) return mergeCallback(flushErr);
-
-				const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-				withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
-					if (countErr) {
-						logger.error('COUNT query failed after retries, aborting importDimension:', countErr);
-						return mergeCallback(countErr);
-					}
-					if (countResults && countResults[0]) {
-						stagingCount = countResults[0].cnt || 0;
-					}
-					withRetry(done => doMerge(sql.mergeDim, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
-				});
+				withRetry(done => doMerge(sql.mergeDim, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
 			});
 		});
 	};

--- a/datalake/lib/dwconnect.js
+++ b/datalake/lib/dwconnect.js
@@ -181,7 +181,6 @@ module.exports = function(dbconfig, options) {
 		const nks = ids;
 		const auditCol = columnConfig._auditdate;
 		const delCol = columnConfig._deleted;
-		const clusterKey = tableDef.clusterKey || null;
 
 		// Resolve the surrogate-key column once — tableDef.structure is fixed
 		// for the duration of this importFact call.
@@ -212,7 +211,6 @@ module.exports = function(dbconfig, options) {
 			const { stagingPath, stagingClause, allCols, fieldLookup } = staged;
 			const auditCols = new Set([auditCol, delCol, columnConfig._current, columnConfig._startdate, columnConfig._enddate, columnConfig._rescued_data]);
 			const dataCols = allCols.filter(c => !nks.includes(c) && !auditCols.has(c));
-			const pruneCol = clusterKey || (ids.length === 1 ? ids[0] : null);
 			let stagingCount = 0;
 
 			// Count sourced from staging rows, not MERGE result (which returns metrics,
@@ -222,37 +220,18 @@ module.exports = function(dbconfig, options) {
 
 			withRetry(done => flushDeletes(client, qualifiedTable, deleteRecords, ids, columnConfig, auditdate, fieldLookup, done), {}, (flushErr) => {
 				if (flushErr) return mergeCallback(flushErr);
-				let naturalKeyFilter = null;
 
-				if (pruneCol) {
-					const minSql = `SELECT MIN(\`${pruneCol.toLowerCase()}\`) AS minval, CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-					const pruneColType = (fieldLookup[pruneCol.toLowerCase()] && fieldLookup[pruneCol.toLowerCase()].data_type) || '';
-					withRetry(done => client.query(minSql, [], done), {}, (qErr, results) => {
-						if (qErr) {
-							logger.error('MIN query failed after retries, aborting importFact:', qErr);
-							return mergeCallback(qErr);
-						}
-						if (results && results[0]) {
-							stagingCount = results[0].cnt || 0;
-							if (results[0].minval != null) {
-								naturalKeyFilter = literalForType(results[0].minval, pruneColType, client.escapeValueNoToLower);
-							}
-						}
-						withRetry(done => doMerge(sql.mergeFact, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, pruneCol, naturalKeyFilter, done), {}, mergeCallback);
-					});
-				} else {
-					const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-					withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
-						if (countErr) {
-							logger.error('COUNT query failed after retries, aborting importFact:', countErr);
-							return mergeCallback(countErr);
-						}
-						if (countResults && countResults[0]) {
-							stagingCount = countResults[0].cnt || 0;
-						}
-						withRetry(done => doMerge(sql.mergeFact, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, clusterKey, null, done), {}, mergeCallback);
-					});
-				}
+				const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
+				withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
+					if (countErr) {
+						logger.error('COUNT query failed after retries, aborting importFact:', countErr);
+						return mergeCallback(countErr);
+					}
+					if (countResults && countResults[0]) {
+						stagingCount = countResults[0].cnt || 0;
+					}
+					withRetry(done => doMerge(sql.mergeFact, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
+				});
 			});
 		});
 	};
@@ -289,7 +268,6 @@ module.exports = function(dbconfig, options) {
 		});
 
 		const auditCol = columnConfig._auditdate;
-		const clusterKey = tableDef.clusterKey || null;
 
 		const skField = tableDef.structure && Object.keys(tableDef.structure).find(k => {
 			const f = tableDef.structure[k];
@@ -316,7 +294,6 @@ module.exports = function(dbconfig, options) {
 			// are managed by the MERGE SQL (sentinel values on INSERT; preserved on UPDATE).
 			const auditCols = new Set([auditCol, columnConfig._current, columnConfig._startdate, columnConfig._enddate, columnConfig._rescued_data]);
 			const dataCols = allCols.filter(c => !nks.includes(c) && !auditCols.has(c));
-			const pruneCol = clusterKey || (nks.length === 1 ? nks[0] : null);
 			let stagingCount = 0;
 
 			const mergeCallback = (mergeErr) =>
@@ -325,37 +302,17 @@ module.exports = function(dbconfig, options) {
 			withRetry(done => flushDimDeletes(client, qualifiedTable, deleteRecords, columnConfig, auditdate, fieldLookup, done), {}, (flushErr) => {
 				if (flushErr) return mergeCallback(flushErr);
 
-				let naturalKeyFilter = null;
-
-				if (pruneCol) {
-					const minSql = `SELECT MIN(\`${pruneCol.toLowerCase()}\`) AS minval, CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-					const pruneColType = (fieldLookup[pruneCol.toLowerCase()] && fieldLookup[pruneCol.toLowerCase()].data_type) || '';
-					withRetry(done => client.query(minSql, [], done), {}, (qErr, results) => {
-						if (qErr) {
-							logger.error('MIN query failed after retries, aborting importDimension:', qErr);
-							return mergeCallback(qErr);
-						}
-						if (results && results[0]) {
-							stagingCount = results[0].cnt || 0;
-							if (results[0].minval != null) {
-								naturalKeyFilter = literalForType(results[0].minval, pruneColType, client.escapeValueNoToLower);
-							}
-						}
-						withRetry(done => doMerge(sql.mergeDim, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, pruneCol, naturalKeyFilter, done), {}, mergeCallback);
-					});
-				} else {
-					const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
-					withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
-						if (countErr) {
-							logger.error('COUNT query failed after retries, aborting importDimension:', countErr);
-							return mergeCallback(countErr);
-						}
-						if (countResults && countResults[0]) {
-							stagingCount = countResults[0].cnt || 0;
-						}
-						withRetry(done => doMerge(sql.mergeDim, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, clusterKey, null, done), {}, mergeCallback);
-					});
-				}
+				const countSql = `SELECT CAST(COUNT(*) AS INT) AS cnt FROM ${stagingClause} AS staging`;
+				withRetry(done => client.query(countSql, [], done), {}, (countErr, countResults) => {
+					if (countErr) {
+						logger.error('COUNT query failed after retries, aborting importDimension:', countErr);
+						return mergeCallback(countErr);
+					}
+					if (countResults && countResults[0]) {
+						stagingCount = countResults[0].cnt || 0;
+					}
+					withRetry(done => doMerge(sql.mergeDim, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, done), {}, mergeCallback);
+				});
 			});
 		});
 	};
@@ -397,20 +354,6 @@ function reconstructType(field) {
 		return `DECIMAL(${p},${s})`;
 	}
 	return t;
-}
-
-// Render `value` as a SQL literal appropriate for `dataType`. Numeric columns
-// take an unquoted literal; everything else (string, timestamp, date) is
-// single-quoted via the connector's standard escaper. Mirrors the type-aware
-// branching in ../postgres/lib/dwconnect.js naturalKeyFilter — Databricks
-// types replace Postgres int4/int8/varchar/timestamp.
-function literalForType(value, dataType, escapeValueNoToLower) {
-	const t = String(dataType || '').toUpperCase();
-	const isNumeric = /^(BIGINT|INT|INTEGER|SMALLINT|TINYINT|DECIMAL|DOUBLE|FLOAT|REAL|NUMERIC)/.test(t);
-	if (isNumeric) {
-		return String(value);
-	}
-	return escapeValueNoToLower(String(value));
 }
 
 function flushDeletes(client, qualifiedTable, deleteRecords, ids, columnConfig, auditdate, fieldLookup, callback) {
@@ -494,15 +437,13 @@ function stageToS3(client, table, pipelinePre, dbconfig, enrichFn, auditdate, ca
 	}).catch(callback);
 }
 
-function doMerge(mergeSqlFn, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, clusterKey, naturalKeyFilter, callback) {
+function doMerge(mergeSqlFn, client, qualifiedTable, stagingClause, nks, dataCols, columnConfig, callback) {
 	const mergeSql = mergeSqlFn(
 		qualifiedTable,
 		stagingClause,
 		nks,
 		dataCols,
 		columnConfig,
-		clusterKey,
-		naturalKeyFilter,
 		client.escapeId
 	);
 
@@ -528,7 +469,7 @@ function cleanupStagedFile(dbconfig, stagingPath, mergeErr, mergeResult, callbac
 // (default 3). Retries only on connection-class errors — query-class errors
 // (SQL syntax, permission, data) propagate immediately. Each retry re-acquires
 // a fresh pool session (the dead one was destroyed by query()'s error handler).
-// Safe because the callers — MIN SELECT, MERGE, flushDeletes UPDATE — are all
+// Safe because the callers — COUNT SELECT, MERGE, flushDeletes UPDATE — are all
 // idempotent: re-running yields the same final state. Never retry inside query()
 // itself (which runs arbitrary, possibly non-idempotent SQL).
 function withRetry(fn, opts, callback) {
@@ -623,8 +564,7 @@ function buildFkEnrichers(structure, columnConfig) {
 	return obj => fns.forEach(fn => fn(obj));
 }
 
-// Exposed for unit testing of the type-aware naturalKeyFilter quoting and retry.
-module.exports.literalForType = literalForType;
+// Exposed for unit testing.
 module.exports.withRetry = withRetry;
 module.exports.dateSk = dateSk;
 module.exports.timeSk = timeSk;

--- a/datalake/lib/sql.js
+++ b/datalake/lib/sql.js
@@ -78,10 +78,11 @@ function colDef(name, rawType, escapeId) {
  * `if (definition.isDimension)` block). Note: SCD is bypassed in all production
  * bot configs (bypassSlowlyChangingDimensions=true, no `scds` fields in any
  * dw_fields), so these columns will be null until dim upsert is implemented.
- * Appends CLUSTER BY (clusterKey) when clusterKey is set.
+ * Always appends CLUSTER BY AUTO so Databricks chooses clustering columns from
+ * observed query patterns (requires Predictive Optimization on the catalog).
  *
  * @param {string} qualifiedTable  - fully-qualified table name (catalog.schema.table)
- * @param {object} definition      - dw_fields entry (structure, isDimension, clusterKey)
+ * @param {object} definition      - dw_fields entry (structure, isDimension)
  * @param {object} columnConfig    - audit column name overrides
  * @param {function} escapeId      - identifier quoting function from connect.js
  * @returns {string} SQL DDL
@@ -132,13 +133,7 @@ function createTable(qualifiedTable, definition, columnConfig, escapeId) {
 	}
 	cols.push(`${escapeId(columnConfig._rescued_data)} STRING`);
 
-	let sql = `CREATE TABLE IF NOT EXISTS ${qualifiedTable} (\n  ${cols.join(',\n  ')}\n) USING DELTA`;
-
-	if (definition.clusterKey) {
-		sql += `\nCLUSTER BY (${escapeId(definition.clusterKey)})`;
-	}
-
-	return sql;
+	return `CREATE TABLE IF NOT EXISTS ${qualifiedTable} (\n  ${cols.join(',\n  ')}\n) USING DELTA\nCLUSTER BY AUTO`;
 }
 
 /**
@@ -167,12 +162,10 @@ function alterColumnType(qualifiedTable, columnName, newRawType, escapeId) {
  * @param {string[]} nks            - natural key column names
  * @param {string[]} dataCols       - non-NK, non-audit data columns
  * @param {object} columnConfig     - audit column name overrides
- * @param {string|null} clusterKey  - reserved, ignored (was incorrectly used as MERGE ON filter)
- * @param {string|null} naturalKeyFilter - reserved, ignored (was incorrectly used as MERGE ON filter)
  * @param {function} escapeId       - identifier quoting function
  * @returns {string} MERGE SQL
  */
-function mergeFact(target, staging, nks, dataCols, columnConfig, clusterKey, naturalKeyFilter, escapeId) {
+function mergeFact(target, staging, nks, dataCols, columnConfig, escapeId) {
 	const ad = escapeId(columnConfig._auditdate);
 	const del = escapeId(columnConfig._deleted);
 	const rd = escapeId(columnConfig._rescued_data);
@@ -220,12 +213,10 @@ function mergeFact(target, staging, nks, dataCols, columnConfig, clusterKey, nat
  * @param {string[]} nks            - natural key column names
  * @param {string[]} dataCols       - non-NK, non-audit data columns
  * @param {object} columnConfig     - audit column name overrides
- * @param {string|null} clusterKey  - reserved, ignored (was incorrectly used as MERGE ON filter)
- * @param {string|null} naturalKeyFilter - reserved, ignored (was incorrectly used as MERGE ON filter)
  * @param {function} escapeId       - identifier quoting function
  * @returns {string} MERGE SQL
  */
-function mergeDim(target, staging, nks, dataCols, columnConfig, clusterKey, naturalKeyFilter, escapeId) {
+function mergeDim(target, staging, nks, dataCols, columnConfig, escapeId) {
 	const ad = escapeId(columnConfig._auditdate);
 	const rd = escapeId(columnConfig._rescued_data);
 

--- a/datalake/test/equivalence/run.js
+++ b/datalake/test/equivalence/run.js
@@ -13,7 +13,6 @@
 // Coverage set requirements (from BUILD_PLAN.md Step 12):
 //   - ≥1 d_* and ≥1 f_* table
 //   - Type coverage: varchar→STRING, timestamp→TIMESTAMP_NTZ, int/bigint, boolean
-//   - ≥1 fact with clusterKey set (exercises naturalKeyFilter MERGE pruning path)
 //   - Mix of single-column and composite natural keys
 //   - Must be a subset of tables the captured dim-queue fixture actually populates
 //

--- a/datalake/test/integration/helpers/test_fact.js
+++ b/datalake/test/integration/helpers/test_fact.js
@@ -18,7 +18,6 @@ const tableDef = {
 		quantity: 'int',
 	},
 	isDimension: false,
-	clusterKey: 'id',
 };
 
 // Deterministic record generator. Counter-based — no PRNG so results are reproducible.

--- a/datalake/test/unit/dwconnect.test.js
+++ b/datalake/test/unit/dwconnect.test.js
@@ -283,39 +283,6 @@ describe('dwconnect.js', () => {
 		});
 	});
 
-	describe('literalForType — type-aware naturalKeyFilter quoting', () => {
-		// Mirrors the dim-vs-fact branching in ../postgres/lib/dwconnect.js
-		// naturalKeyFilter: numeric column types render as unquoted literals
-		// (so >= compares numerically), everything else quoted.
-		const { literalForType } = require('../../lib/dwconnect.js');
-		const escape = v => typeof v === 'string' ? `'${v.replace(/'/g, "\\'")}'` : v;
-
-		it('numeric types render unquoted', () => {
-			expect(literalForType(12345, 'BIGINT', escape)).to.equal('12345');
-			expect(literalForType(7, 'INT', escape)).to.equal('7');
-			expect(literalForType(42, 'INTEGER', escape)).to.equal('42');
-			expect(literalForType('99.5', 'DECIMAL', escape)).to.equal('99.5');
-			expect(literalForType(1.5, 'DOUBLE', escape)).to.equal('1.5');
-		});
-
-		it('string and timestamp types render quoted', () => {
-			expect(literalForType('abc', 'STRING', escape)).to.equal("'abc'");
-			expect(literalForType('2026-01-01 00:00:00', 'TIMESTAMP_NTZ', escape))
-				.to.equal("'2026-01-01 00:00:00'");
-			expect(literalForType('2026-01-01', 'DATE', escape)).to.equal("'2026-01-01'");
-		});
-
-		it('case-insensitive on type name', () => {
-			expect(literalForType(1, 'bigint', escape)).to.equal('1');
-			expect(literalForType('x', 'string', escape)).to.equal("'x'");
-		});
-
-		it('unknown type falls back to quoted (safe default)', () => {
-			expect(literalForType('x', '', escape)).to.equal("'x'");
-			expect(literalForType('x', undefined, escape)).to.equal("'x'");
-		});
-	});
-
 	describe('withRetry — bounded idempotent retry', () => {
 		const { withRetry } = require('../../lib/dwconnect.js');
 

--- a/datalake/test/unit/importDimension.test.js
+++ b/datalake/test/unit/importDimension.test.js
@@ -6,8 +6,8 @@ const proxyquire = require('proxyquire').noCallThru();
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Orchestration tests for importDimension: covers the S3-staging + MERGE wiring,
-// prune-query type-aware quoting, error propagation, delete-marker filtering,
-// and row enrichment (sk + auditdate, no _deleted).
+// error propagation, delete-marker filtering, and row enrichment (sk + auditdate,
+// no _deleted).
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('importDimension — orchestration', () => {
@@ -34,10 +34,6 @@ describe('importDimension — orchestration', () => {
 			query: sinon.stub().callsFake((sql, params, cb) => {
 				queryHistory.push(sql);
 				const finalCb = typeof cb === 'function' ? cb : (typeof params === 'function' ? params : () => {});
-				if (sql.indexOf('SELECT MIN(') === 0) {
-					if (opts.failMinQuery) return finalCb(new Error('MIN query failed'));
-					return finalCb(null, [{ minval: opts.minVal !== undefined ? opts.minVal : 100, cnt: opts.cnt !== undefined ? opts.cnt : 50 }]);
-				}
 				if (sql.indexOf('SELECT CAST(COUNT(') === 0) {
 					if (opts.failCountQuery) return finalCb(new Error('COUNT query failed'));
 					return finalCb(null, [{ cnt: opts.cnt !== undefined ? opts.cnt : 50 }]);
@@ -124,42 +120,17 @@ describe('importDimension — orchestration', () => {
 		expect(merge).to.not.include('_deleted');
 	});
 
-	it('runs a SELECT MIN prune query against the single NK', async () => {
+	it('runs a SELECT COUNT query before MERGE', async () => {
 		const ctx = setup({ tableFields: dimTableFields });
 		await runToCompletion(ctx, 'd_account', ['retailer_id']);
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery, 'expected a prune MIN query').to.exist;
-		expect(minQuery).to.include('`retailer_id`');
-	});
-
-	it('prune filter is NOT injected into the MERGE ON clause (regression: would duplicate rows with old cluster keys)', async () => {
-		const ctx = setup({ tableFields: dimTableFields, minVal: 99 });
-		await runToCompletion(ctx, 'd_account', ['retailer_id']); // no clusterKey — pruneCol falls back to single NK
-		const merge = ctx.queryHistory.find(q => q.startsWith('MERGE INTO'));
-		expect(merge, 'expected a MERGE INTO query').to.exist;
-		expect(merge).to.not.include('>=');
-	});
-
-	it('prefers tableDef.clusterKey over nk as the prune column', async () => {
-		const ctx = setup({ tableFields: dimTableFields });
-		await runToCompletion(ctx, 'd_account', ['retailer_id'], { clusterKey: 'name' });
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery).to.include('`name`');
-		expect(minQuery).to.not.include('MIN(`retailer_id`)');
-	});
-
-	it('skips prune query for composite NKs when no clusterKey is set', async () => {
-		const ctx = setup({ tableFields: dimTableFields });
-		await runToCompletion(ctx, 'd_account', ['retailer_id', 'name']);
-		expect(ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0)).to.not.exist;
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.exist;
+		const countQuery = ctx.queryHistory.find(q => q.indexOf('SELECT CAST(COUNT(') === 0);
+		expect(countQuery, 'expected a COUNT query').to.exist;
 	});
 
 	it('normalizes a single non-array nk to an array', async () => {
 		const ctx = setup({ tableFields: dimTableFields });
 		await runToCompletion(ctx, 'd_account', 'retailer_id');
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery).to.include('`retailer_id`');
+		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.exist;
 	});
 
 	it('propagates a pipeline error to the callback and skips MERGE', async () => {
@@ -260,7 +231,7 @@ describe('importDimension — orchestration', () => {
 		expect(ctx.queryHistory.find(q => q.startsWith('UPDATE'))).to.not.exist;
 	});
 
-	it('returns staging cnt as result.count (single NK — pruneCol path)', async () => {
+	it('returns staging cnt as result.count', async () => {
 		const ctx = setup({ tableFields: dimTableFields, cnt: 42 });
 		const result = await runToCompletion(ctx, 'd_account', ['retailer_id']);
 		expect(result).to.exist;
@@ -274,16 +245,16 @@ describe('importDimension — orchestration', () => {
 		expect(result.count).to.equal(17);
 	});
 
-	it('propagates a MIN query error and skips MERGE', async () => {
-		const ctx = setup({ tableFields: dimTableFields, failMinQuery: true });
+	it('propagates a COUNT query error and skips MERGE', async () => {
+		const ctx = setup({ tableFields: dimTableFields, failCountQuery: true });
 		let caught;
 		try {
 			await runToCompletion(ctx, 'd_account', ['retailer_id']);
 		} catch (e) {
 			caught = e;
 		}
-		expect(caught, 'expected an error from MIN query').to.exist;
-		expect(caught.message).to.equal('MIN query failed');
+		expect(caught, 'expected an error from COUNT query').to.exist;
+		expect(caught.message).to.equal('COUNT query failed');
 		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
 	});
 

--- a/datalake/test/unit/importDimension.test.js
+++ b/datalake/test/unit/importDimension.test.js
@@ -34,10 +34,6 @@ describe('importDimension — orchestration', () => {
 			query: sinon.stub().callsFake((sql, params, cb) => {
 				queryHistory.push(sql);
 				const finalCb = typeof cb === 'function' ? cb : (typeof params === 'function' ? params : () => {});
-				if (sql.indexOf('SELECT CAST(COUNT(') === 0) {
-					if (opts.failCountQuery) return finalCb(new Error('COUNT query failed'));
-					return finalCb(null, [{ cnt: opts.cnt !== undefined ? opts.cnt : 50 }]);
-				}
 				if (sql.startsWith('UPDATE') && opts.failDimDeleteUpdate) return finalCb(new Error('UPDATE failed'));
 				return finalCb(null, []);
 			}),
@@ -118,13 +114,6 @@ describe('importDimension — orchestration', () => {
 		await runToCompletion(ctx, 'd_account', ['retailer_id']);
 		const merge = ctx.queryHistory.find(q => q.startsWith('MERGE INTO'));
 		expect(merge).to.not.include('_deleted');
-	});
-
-	it('runs a SELECT COUNT query before MERGE', async () => {
-		const ctx = setup({ tableFields: dimTableFields });
-		await runToCompletion(ctx, 'd_account', ['retailer_id']);
-		const countQuery = ctx.queryHistory.find(q => q.indexOf('SELECT CAST(COUNT(') === 0);
-		expect(countQuery, 'expected a COUNT query').to.exist;
 	});
 
 	it('normalizes a single non-array nk to an array', async () => {
@@ -231,44 +220,30 @@ describe('importDimension — orchestration', () => {
 		expect(ctx.queryHistory.find(q => q.startsWith('UPDATE'))).to.not.exist;
 	});
 
-	it('returns staging cnt as result.count', async () => {
-		const ctx = setup({ tableFields: dimTableFields, cnt: 42 });
-		const result = await runToCompletion(ctx, 'd_account', ['retailer_id']);
-		expect(result).to.exist;
-		expect(result.count).to.equal(42);
+	it('result.count reflects the number of rows enriched through staging', async () => {
+		const ctx = setup({ tableFields: dimTableFields });
+		const p = callImportDimension(ctx.dwClient, 'd_account', ['retailer_id']);
+		await new Promise(setImmediate);
+		const enrichCb = ctx.throughCallbacks[1];
+		enrichCb({ retailer_id: 1 }, () => {});
+		enrichCb({ retailer_id: 2 }, () => {});
+		ctx.completePipeline();
+		const result = await p;
+		expect(result.count).to.equal(2);
 	});
 
-	it('returns staging cnt as result.count (composite NK — COUNT path)', async () => {
-		const ctx = setup({ tableFields: dimTableFields, cnt: 17 });
-		const result = await runToCompletion(ctx, 'd_account', ['retailer_id', 'name']);
-		expect(result).to.exist;
-		expect(result.count).to.equal(17);
-	});
-
-	it('propagates a COUNT query error and skips MERGE', async () => {
-		const ctx = setup({ tableFields: dimTableFields, failCountQuery: true });
-		let caught;
-		try {
-			await runToCompletion(ctx, 'd_account', ['retailer_id']);
-		} catch (e) {
-			caught = e;
-		}
-		expect(caught, 'expected an error from COUNT query').to.exist;
-		expect(caught.message).to.equal('COUNT query failed');
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
-	});
-
-	it('propagates a COUNT query error and skips MERGE (composite NK path)', async () => {
-		const ctx = setup({ tableFields: dimTableFields, failCountQuery: true });
-		let caught;
-		try {
-			await runToCompletion(ctx, 'd_account', ['retailer_id', 'name']);
-		} catch (e) {
-			caught = e;
-		}
-		expect(caught, 'expected an error from COUNT query').to.exist;
-		expect(caught.message).to.equal('COUNT query failed');
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
+	it('id-marked __leo_delete__ records pushed to staging do not contribute to result.count', async () => {
+		// id-marked deletes are pushed downstream by dataStream so they reach enrichFn,
+		// but they are delete markers, not data records — they should not be counted.
+		const ctx = setup({ tableFields: dimTableFields });
+		const p = callImportDimension(ctx.dwClient, 'd_account', ['retailer_id']);
+		await new Promise(setImmediate);
+		const enrichCb = ctx.throughCallbacks[1];
+		enrichCb({ __leo_delete__: 'id', __leo_delete_id__: 42 }, () => {});
+		enrichCb({ retailer_id: 1 }, () => {});
+		ctx.completePipeline();
+		const result = await p;
+		expect(result.count).to.equal(1);
 	});
 
 	it('enrichedStream stamps auditdate and computes sk, but does NOT set _deleted', async () => {

--- a/datalake/test/unit/importFact.test.js
+++ b/datalake/test/unit/importFact.test.js
@@ -173,10 +173,6 @@ describe('importFact — orchestration', () => {
 				if (opts.failFlushDeletes && /^UPDATE\s/i.test(sql)) {
 					return finalCb(new Error('flush delete failed'));
 				}
-				if (sql.indexOf('SELECT CAST(COUNT(') === 0) {
-					if (opts.failCountQuery) return finalCb(new Error('COUNT query failed'));
-					return finalCb(null, [{ cnt: opts.cnt !== undefined ? opts.cnt : 50 }]);
-				}
 				return finalCb(null, []);
 			}),
 		};
@@ -251,13 +247,6 @@ describe('importFact — orchestration', () => {
 		expect(merge).to.include('cat.sch.f_order_item');
 	});
 
-	it('runs a SELECT COUNT query before MERGE', async () => {
-		const ctx = setup({ tableFields: factTableFields });
-		await runToCompletion(ctx, 'f_order_item', ['id']);
-		const countQuery = ctx.queryHistory.find(q => q.indexOf('SELECT CAST(COUNT(') === 0);
-		expect(countQuery, 'expected a COUNT query').to.exist;
-	});
-
 	it('normalizes a single non-array id to an array', async () => {
 		const ctx = setup({ tableFields: factTableFields });
 		await runToCompletion(ctx, 'f_order_item', 'id');
@@ -293,11 +282,35 @@ describe('importFact — orchestration', () => {
 		expect(forwarded).to.deep.equal([{ id: 1, qty: 5 }]);
 	});
 
-	it('returns staging cnt as result.count', async () => {
-		const ctx = setup({ tableFields: factTableFields, cnt: 77 });
-		const result = await runToCompletion(ctx, 'f_order_item', ['id']);
-		expect(result).to.exist;
-		expect(result.count).to.equal(77);
+	it('result.count reflects the number of rows enriched through staging', async () => {
+		const ctx = setup({ tableFields: factTableFields });
+		const p = callImportFact(ctx.dwClient, 'f_order_item', ['id']);
+		await new Promise(setImmediate);
+		// throughCallbacks[1] is the enrichedStream (registered inside stageToS3 after
+		// describeTable/ensureStagingLocation resolve). Drive 3 records through it to
+		// verify stagingCount increments correctly.
+		const enrichCb = ctx.throughCallbacks[1];
+		enrichCb({ id: 1 }, () => {});
+		enrichCb({ id: 2 }, () => {});
+		enrichCb({ id: 3 }, () => {});
+		ctx.completePipeline();
+		const result = await p;
+		expect(result.count).to.equal(3);
+	});
+
+	it('__leo_delete__ records do not contribute to result.count', async () => {
+		// Delete records are filtered by dataStream before reaching enrichFn — they
+		// should not inflate the staged-record count.
+		const ctx = setup({ tableFields: factTableFields });
+		const p = callImportFact(ctx.dwClient, 'f_order_item', ['id']);
+		await new Promise(setImmediate);
+		const dataStreamCb = ctx.throughCallbacks[0];
+		const enrichCb = ctx.throughCallbacks[1];
+		dataStreamCb({ __leo_delete__: 'id', __leo_delete_id__: 99 }, () => {});
+		enrichCb({ id: 1 }, () => {});
+		ctx.completePipeline();
+		const result = await p;
+		expect(result.count).to.equal(1);
 	});
 
 	it('propagates a flushDeletes error and skips MERGE', async () => {
@@ -323,32 +336,6 @@ describe('importFact — orchestration', () => {
 		ctx.completePipeline();
 		await p;
 		expect(ctx.queryHistory.find(q => q.startsWith('UPDATE'))).to.not.exist;
-	});
-
-	it('propagates a COUNT query error and skips MERGE', async () => {
-		const ctx = setup({ tableFields: factTableFields, failCountQuery: true });
-		let caught;
-		try {
-			await runToCompletion(ctx, 'f_order_item', ['id']);
-		} catch (e) {
-			caught = e;
-		}
-		expect(caught, 'expected an error from COUNT query').to.exist;
-		expect(caught.message).to.equal('COUNT query failed');
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
-	});
-
-	it('propagates a COUNT query error and skips MERGE (composite NK path)', async () => {
-		const ctx = setup({ tableFields: factTableFields, failCountQuery: true });
-		let caught;
-		try {
-			await runToCompletion(ctx, 'f_order_item', ['id', 'qty']);
-		} catch (e) {
-			caught = e;
-		}
-		expect(caught, 'expected an error from COUNT query').to.exist;
-		expect(caught.message).to.equal('COUNT query failed');
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
 	});
 
 	it('enrichedStream stamps audit/_deleted and computes sk via fingerprint64', async () => {

--- a/datalake/test/unit/importFact.test.js
+++ b/datalake/test/unit/importFact.test.js
@@ -133,9 +133,9 @@ describe('importFact — CSV output contract', () => {
 
 // ─────────────────────────────────────────────────────────────────────────
 // Orchestration tests: cover importFact's wiring of describeTable →
-// ensureStagingLocation → streamToTableFromS3 → MERGE, plus prune-query
-// type-aware quoting, error propagation, and the row-level routing
-// (delete records out, sk + audit + _deleted onto every survivor).
+// ensureStagingLocation → streamToTableFromS3 → MERGE, plus error propagation
+// and the row-level routing (delete records out, sk + audit + _deleted onto
+// every survivor).
 //
 // leo-sdk.streams is the canonical leo-streams package (cf. connect.js);
 // we stub it so ls.pipe completes synchronously and ls.through hands us
@@ -172,10 +172,6 @@ describe('importFact — orchestration', () => {
 				const finalCb = typeof cb === 'function' ? cb : (typeof params === 'function' ? params : () => {});
 				if (opts.failFlushDeletes && /^UPDATE\s/i.test(sql)) {
 					return finalCb(new Error('flush delete failed'));
-				}
-				if (sql.indexOf('SELECT MIN(') === 0) {
-					if (opts.failMinQuery) return finalCb(new Error('MIN query failed'));
-					return finalCb(null, [{ minval: opts.minVal !== undefined ? opts.minVal : 100, cnt: opts.cnt !== undefined ? opts.cnt : 50 }]);
 				}
 				if (sql.indexOf('SELECT CAST(COUNT(') === 0) {
 					if (opts.failCountQuery) return finalCb(new Error('COUNT query failed'));
@@ -255,56 +251,17 @@ describe('importFact — orchestration', () => {
 		expect(merge).to.include('cat.sch.f_order_item');
 	});
 
-	it('runs a SELECT MIN prune query against the single NK', async () => {
+	it('runs a SELECT COUNT query before MERGE', async () => {
 		const ctx = setup({ tableFields: factTableFields });
 		await runToCompletion(ctx, 'f_order_item', ['id']);
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery, 'expected a prune MIN query').to.exist;
-		expect(minQuery).to.include('`id`');
-	});
-
-	it('prefers tableDef.clusterKey over ids as the prune column', async () => {
-		const ctx = setup({ tableFields: factTableFields });
-		await runToCompletion(ctx, 'f_order_item', ['id'], { clusterKey: 'qty' });
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery).to.include('`qty`');
-		expect(minQuery).to.not.include('MIN(`id`)');
-	});
-
-	it('prune filter is NOT injected into the MERGE ON clause (regression: would duplicate rows with old cluster keys)', async () => {
-		const ctx = setup({ tableFields: factTableFields, minVal: 42 });
-		await runToCompletion(ctx, 'f_order_item', ['id']); // no clusterKey — pruneCol falls back to single NK
-		const merge = ctx.queryHistory.find(q => q.startsWith('MERGE INTO'));
-		expect(merge, 'expected a MERGE INTO query').to.exist;
-		expect(merge).to.not.include('>=');
-	});
-
-	it('naturalKeyFilter is computed but NOT injected into MERGE ON (numeric case)', async () => {
-		const ctx = setup({ tableFields: factTableFields, minVal: 12345 });
-		await runToCompletion(ctx, 'f_order_item', ['id'], { clusterKey: 'id' });
-		const merge = ctx.queryHistory.find(q => q.startsWith('MERGE INTO'));
-		expect(merge).to.not.include('>=');
-	});
-
-	it('naturalKeyFilter is computed but NOT injected into MERGE ON (timestamp case)', async () => {
-		const ctx = setup({ tableFields: factTableFields, minVal: '2026-03-15 14:30:00' });
-		await runToCompletion(ctx, 'f_order_item', ['id'], { clusterKey: 'created_at' });
-		const merge = ctx.queryHistory.find(q => q.startsWith('MERGE INTO'));
-		expect(merge).to.not.include('>=');
-	});
-
-	it('skips prune query for composite NKs when no clusterKey is set', async () => {
-		const ctx = setup({ tableFields: factTableFields });
-		await runToCompletion(ctx, 'f_order_item', ['id', 'qty']);
-		expect(ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0)).to.not.exist;
-		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.exist;
+		const countQuery = ctx.queryHistory.find(q => q.indexOf('SELECT CAST(COUNT(') === 0);
+		expect(countQuery, 'expected a COUNT query').to.exist;
 	});
 
 	it('normalizes a single non-array id to an array', async () => {
 		const ctx = setup({ tableFields: factTableFields });
 		await runToCompletion(ctx, 'f_order_item', 'id');
-		const minQuery = ctx.queryHistory.find(q => q.indexOf('SELECT MIN(') === 0);
-		expect(minQuery).to.include('`id`');
+		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.exist;
 	});
 
 	it('propagates a pipeline error to the callback and skips MERGE', async () => {
@@ -336,18 +293,11 @@ describe('importFact — orchestration', () => {
 		expect(forwarded).to.deep.equal([{ id: 1, qty: 5 }]);
 	});
 
-	it('returns staging cnt as result.count (single NK — pruneCol path)', async () => {
+	it('returns staging cnt as result.count', async () => {
 		const ctx = setup({ tableFields: factTableFields, cnt: 77 });
 		const result = await runToCompletion(ctx, 'f_order_item', ['id']);
 		expect(result).to.exist;
 		expect(result.count).to.equal(77);
-	});
-
-	it('returns staging cnt as result.count (composite NK — COUNT path)', async () => {
-		const ctx = setup({ tableFields: factTableFields, cnt: 33 });
-		const result = await runToCompletion(ctx, 'f_order_item', ['id', 'qty']);
-		expect(result).to.exist;
-		expect(result.count).to.equal(33);
 	});
 
 	it('propagates a flushDeletes error and skips MERGE', async () => {
@@ -375,16 +325,16 @@ describe('importFact — orchestration', () => {
 		expect(ctx.queryHistory.find(q => q.startsWith('UPDATE'))).to.not.exist;
 	});
 
-	it('propagates a MIN query error and skips MERGE', async () => {
-		const ctx = setup({ tableFields: factTableFields, failMinQuery: true });
+	it('propagates a COUNT query error and skips MERGE', async () => {
+		const ctx = setup({ tableFields: factTableFields, failCountQuery: true });
 		let caught;
 		try {
 			await runToCompletion(ctx, 'f_order_item', ['id']);
 		} catch (e) {
 			caught = e;
 		}
-		expect(caught, 'expected an error from MIN query').to.exist;
-		expect(caught.message).to.equal('MIN query failed');
+		expect(caught, 'expected an error from COUNT query').to.exist;
+		expect(caught.message).to.equal('COUNT query failed');
 		expect(ctx.queryHistory.find(q => q.startsWith('MERGE INTO'))).to.not.exist;
 	});
 

--- a/datalake/test/unit/load.smoke.test.js
+++ b/datalake/test/unit/load.smoke.test.js
@@ -6,8 +6,8 @@
 // combine.js sort-and-dedup) into the real lib/dwconnect.js importFact, with the
 // Databricks SQL layer (connect.js) and S3 staging stubbed at the connect.js boundary.
 //
-// This guards the load.js → dwconnect.js dispatch wiring: if importFact's signature,
-// the COUNT query, or the MERGE callback path drift, this test breaks before production does.
+// This guards the load.js → dwconnect.js dispatch wiring: if importFact's signature
+// or the MERGE callback path drift, this test breaks before production does.
 
 const fs = require('fs');
 const { expect } = require('chai');
@@ -67,7 +67,6 @@ describe('load.js smoke — offline wiring guard', function() {
 	let connectClientStub;
 	let insertMissingDimensionsCalls;
 	let dropTempTablesCalls;
-	let countQueryCount;
 	let mergeQueryCount;
 
 	before(function(done) {
@@ -78,7 +77,6 @@ describe('load.js smoke — offline wiring guard', function() {
 
 		insertMissingDimensionsCalls = [];
 		dropTempTablesCalls = 0;
-		countQueryCount = 0;
 		mergeQueryCount = 0;
 
 		connectClientStub = {
@@ -99,13 +97,8 @@ describe('load.js smoke — offline wiring guard', function() {
 			buildStagingSelect: sinon.stub().returns('SELECT * FROM smoke_staging'),
 			query: sinon.stub().callsFake((sql, _params, cb) => {
 				const done = typeof cb === 'function' ? cb : (typeof _params === 'function' ? _params : () => {});
-				if (/SELECT CAST\(COUNT/.test(sql)) {
-					countQueryCount++;
-					return done(null, [{ cnt: 100 }]);
-				}
 				if (/^MERGE INTO/.test(sql)) {
 					mergeQueryCount++;
-					return done(null, []);
 				}
 				return done(null, []);
 			}),
@@ -151,10 +144,6 @@ describe('load.js smoke — offline wiring guard', function() {
 	it('stages records to S3 via streamToTableFromS3', () => {
 		expect(connectClientStub.streamToTableFromS3.callCount, 'streamToTableFromS3 call count').to.equal(1);
 		expect(connectClientStub.streamToTableFromS3.firstCall.args[0]).to.equal(TABLE);
-	});
-
-	it('runs the COUNT query against the staging clause', () => {
-		expect(countQueryCount, 'COUNT query count').to.equal(1);
 	});
 
 	it('runs the MERGE INTO query', () => {

--- a/datalake/test/unit/load.smoke.test.js
+++ b/datalake/test/unit/load.smoke.test.js
@@ -7,7 +7,7 @@
 // Databricks SQL layer (connect.js) and S3 staging stubbed at the connect.js boundary.
 //
 // This guards the load.js → dwconnect.js dispatch wiring: if importFact's signature,
-// the MIN query, or the MERGE callback path drift, this test breaks before production does.
+// the COUNT query, or the MERGE callback path drift, this test breaks before production does.
 
 const fs = require('fs');
 const { expect } = require('chai');
@@ -24,7 +24,6 @@ const TABLE = 'f_smoke_test';
 const tableDef = {
 	identifier: TABLE,
 	isDimension: false,
-	clusterKey: 'id',
 	structure: {
 		id:       { type: 'bigint', nk: true },
 		name:     { type: 'varchar(100)' },
@@ -68,7 +67,7 @@ describe('load.js smoke — offline wiring guard', function() {
 	let connectClientStub;
 	let insertMissingDimensionsCalls;
 	let dropTempTablesCalls;
-	let minQueryCount;
+	let countQueryCount;
 	let mergeQueryCount;
 
 	before(function(done) {
@@ -79,7 +78,7 @@ describe('load.js smoke — offline wiring guard', function() {
 
 		insertMissingDimensionsCalls = [];
 		dropTempTablesCalls = 0;
-		minQueryCount = 0;
+		countQueryCount = 0;
 		mergeQueryCount = 0;
 
 		connectClientStub = {
@@ -100,11 +99,8 @@ describe('load.js smoke — offline wiring guard', function() {
 			buildStagingSelect: sinon.stub().returns('SELECT * FROM smoke_staging'),
 			query: sinon.stub().callsFake((sql, _params, cb) => {
 				const done = typeof cb === 'function' ? cb : (typeof _params === 'function' ? _params : () => {});
-				if (/SELECT MIN\(/.test(sql)) {
-					minQueryCount++;
-					return done(null, [{ minval: 1, cnt: 100 }]);
-				}
 				if (/SELECT CAST\(COUNT/.test(sql)) {
+					countQueryCount++;
 					return done(null, [{ cnt: 100 }]);
 				}
 				if (/^MERGE INTO/.test(sql)) {
@@ -157,8 +153,8 @@ describe('load.js smoke — offline wiring guard', function() {
 		expect(connectClientStub.streamToTableFromS3.firstCall.args[0]).to.equal(TABLE);
 	});
 
-	it('runs the MIN prune query against the staging clause', () => {
-		expect(minQueryCount, 'MIN query count').to.equal(1);
+	it('runs the COUNT query against the staging clause', () => {
+		expect(countQueryCount, 'COUNT query count').to.equal(1);
 	});
 
 	it('runs the MERGE INTO query', () => {

--- a/datalake/test/unit/sql.test.js
+++ b/datalake/test/unit/sql.test.js
@@ -116,15 +116,9 @@ describe('sql.js', () => {
 			expect(ddl).to.not.include('`_current`');
 		});
 
-		it('appends CLUSTER BY when clusterKey set', () => {
-			const def = Object.assign({}, dOrderDef, { clusterKey: 'id' });
-			const ddl = createTable('cat.sch.f_order_item', def, columnConfig, escapeId);
-			expect(ddl).to.include('CLUSTER BY (`id`)');
-		});
-
-		it('omits CLUSTER BY when clusterKey absent', () => {
+		it('always appends CLUSTER BY AUTO', () => {
 			const ddl = createTable('cat.sch.d_order', dOrderDef, columnConfig, escapeId);
-			expect(ddl).to.not.include('CLUSTER BY');
+			expect(ddl).to.include('CLUSTER BY AUTO');
 		});
 
 		it('lowercases all identifiers via escapeId', () => {
@@ -237,45 +231,39 @@ describe('sql.js', () => {
 		const dataCols = ['channel', 'cost', 'archived'];
 
 		it('emits MERGE INTO ... USING ... ON', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('MERGE INTO cat.sch.f_order AS target');
 			expect(m).to.include('USING `staging_f_order` AS staging');
 			expect(m).to.include('ON (target.`id` = staging.`id`)');
 		});
 
 		it('emits WHEN MATCHED UPDATE with COALESCE', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('WHEN MATCHED THEN UPDATE SET');
 			expect(m).to.include('COALESCE(staging.`channel`, target.`channel`)');
 		});
 
 		it('sets _deleted=false, _auditdate, and _rescued_data in UPDATE', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('`_deleted` = false');
 			expect(m).to.include('`_auditdate` = staging.`_auditdate`');
 			expect(m).to.include('`_rescued_data` = staging.`_rescued_data`');
 		});
 
 		it('includes _rescued_data in INSERT', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, escapeId);
 			const insertBlock = m.split('WHEN NOT MATCHED')[1];
 			expect(insertBlock).to.include('`_rescued_data`');
 			expect(insertBlock).to.include('staging.`_rescued_data`');
 		});
 
 		it('emits WHEN NOT MATCHED INSERT', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('WHEN NOT MATCHED THEN INSERT');
 		});
 
-		it('does NOT add clusterKey filter to ON clause (regression: would duplicate rows with old cluster keys)', () => {
-			const m = mergeFact('cat.sch.f_order', '`staging_f_order`', nks, dataCols, columnConfig, 'id', '1000', escapeId);
-			expect(m).to.not.include('>=');
-			expect(m).to.include('ON (target.`id` = staging.`id`)');
-		});
-
 		it('handles composite natural keys', () => {
-			const m = mergeFact('cat.sch.f_test', '`staging_f_test`', ['a', 'b'], ['c'], columnConfig, null, null, escapeId);
+			const m = mergeFact('cat.sch.f_test', '`staging_f_test`', ['a', 'b'], ['c'], columnConfig, escapeId);
 			expect(m).to.include('target.`a` = staging.`a` AND target.`b` = staging.`b`');
 		});
 	});
@@ -285,14 +273,14 @@ describe('sql.js', () => {
 		const dataCols = ['name', 'status'];
 
 		it('emits MERGE INTO ... USING ... ON', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('MERGE INTO cat.sch.d_account AS target');
 			expect(m).to.include('USING `staging_d_account` AS staging');
 			expect(m).to.include('ON (target.`retailer_id` = staging.`retailer_id`)');
 		});
 
 		it('MATCHED UPDATE includes data cols with COALESCE, _auditdate, and _rescued_data', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('WHEN MATCHED THEN UPDATE SET');
 			expect(m).to.include('COALESCE(staging.`name`, target.`name`)');
 			expect(m).to.include('`_auditdate` = staging.`_auditdate`');
@@ -300,14 +288,14 @@ describe('sql.js', () => {
 		});
 
 		it('NOT MATCHED INSERT includes _rescued_data from staging', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			const insertBlock = m.split('WHEN NOT MATCHED')[1];
 			expect(insertBlock).to.include('`_rescued_data`');
 			expect(insertBlock).to.include('staging.`_rescued_data`');
 		});
 
 		it('MATCHED UPDATE does NOT touch _startdate, _enddate, or _current', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			// Split on the UPDATE SET block to check only the matched section
 			const matchedBlock = m.split('WHEN NOT MATCHED')[0];
 			expect(matchedBlock).to.not.include('_startdate');
@@ -316,7 +304,7 @@ describe('sql.js', () => {
 		});
 
 		it('NOT MATCHED INSERT uses sentinel values for _current/_startdate/_enddate', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.include('WHEN NOT MATCHED THEN INSERT');
 			expect(m).to.include('`_current`');
 			expect(m).to.include('`_startdate`');
@@ -327,18 +315,12 @@ describe('sql.js', () => {
 		});
 
 		it('does NOT set _deleted in any clause', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, escapeId);
 			expect(m).to.not.include('_deleted');
 		});
 
-		it('does NOT add clusterKey filter to ON clause (regression: would duplicate rows with old cluster keys)', () => {
-			const m = mergeDim('cat.sch.d_account', '`staging_d_account`', nks, dataCols, columnConfig, 'retailer_id', '1000', escapeId);
-			expect(m).to.not.include('>=');
-			expect(m).to.include('ON (target.`retailer_id` = staging.`retailer_id`)');
-		});
-
 		it('handles composite natural keys', () => {
-			const m = mergeDim('cat.sch.d_test', '`staging_d_test`', ['a', 'b'], ['c'], columnConfig, null, null, escapeId);
+			const m = mergeDim('cat.sch.d_test', '`staging_d_test`', ['a', 'b'], ['c'], columnConfig, escapeId);
 			expect(m).to.include('target.`a` = staging.`a` AND target.`b` = staging.`b`');
 		});
 	});


### PR DESCRIPTION
## Summary

- **Drop `clusterKey` from `dw_fields`**: the field drove `CLUSTER BY (col)` in `createTable` and a `MIN(staging_col)` pruning predicate in the MERGE; both are gone. Every table now declares `CLUSTER BY AUTO` — Databricks Predictive Optimization chooses columns from observed query patterns.
- **Remove `pruneCol`/`naturalKeyFilter`/`literalForType` apparatus** from `lib/dwconnect.js`: both `importFact` and `importDimension` now increment a counter in `enrichFn` per staged row and go directly to MERGE — no extra DB round-trip, no type-aware quoting, no pruneCol branch.
- **`lib/sql.js`**: `mergeFact`/`mergeDim` signatures drop the two dead params; `createTable` drops the conditional `CLUSTER BY (col)` in favour of unconditional `CLUSTER BY AUTO`.
- **All docs updated in the same commit**: `CLAUDE.md`, `BUILD_PLAN.md`, `NEXT_WORK_LIST.md`, `porting-decisions.md` — Facundo's review comment was specifically about keeping decision records current.

This change was requested by John Cronin in PR #235 review (2026-06-24): the `clusterKey` apparatus had become an "AI echo chamber" — intent docs drove misinterpretation drove dead code. Removing it is cleaner than maintaining it.

## Scope notes

- **No Redshift impact**: `clusterKey` was already ignored by `leo-connector-postgres`; no producer `dw_fields` JSONs (order/account/item/general) contain the field; it was optional, so the Redshift pipeline is unaffected.
- **Existing Databricks tables**: any table already created with explicit `CLUSTER BY (col)` should be migrated via `ALTER TABLE … CLUSTER BY AUTO` (one-time DDL from a notebook — out of scope for this commit).
- **Stacks on**: this branch targets `feature/datalake-connector` (PR #235).

## Test plan

- [x] `npm run lint` — passes
- [x] `npm test` — 186 passing, 0 failing
- [x] `npm run test:int-local` — 23 passing, all integration tests green against dev Databricks workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)