### PR TITLE
fix(datalake): revert leo-connector-common to 4.0.13-rc

### DIFF
--- a/datalake/package-lock.json
+++ b/datalake/package-lock.json
@@ -14,7 +14,7 @@
 				"farmhash-modern": "^1.1.0",
 				"fast-csv": "2.4.1",
 				"generic-pool": "^3.9.0",
-				"leo-connector-common": "5.0.3",
+				"leo-connector-common": "4.0.13-rc",
 				"leo-logger": "1.0.1",
 				"leo-sdk": "7.1.12",
 				"leo-streams": "2.0.0",
@@ -74,6 +74,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
 			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -115,6 +116,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-js": "^5.2.0",
@@ -130,6 +132,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -144,6 +147,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -153,6 +157,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
@@ -296,6 +301,7 @@
 			"version": "3.1075.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1075.0.tgz",
 			"integrity": "sha512-S+sy0L7WEouGGys0kJZJ+br0sQGxgWC+0nR/4ySsym/CSg/k+VHXBdD697WJLli+X5a76tFBshx5bjgVKgLg4Q==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -388,6 +394,7 @@
 			"version": "3.974.23",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
 			"integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.13",
@@ -424,6 +431,7 @@
 			"version": "3.972.49",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
 			"integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -440,6 +448,7 @@
 			"version": "3.972.51",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
 			"integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -458,6 +467,7 @@
 			"version": "3.972.56",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
 			"integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -482,6 +492,7 @@
 			"version": "3.972.55",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
 			"integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -499,6 +510,7 @@
 			"version": "3.972.58",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
 			"integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "^3.972.49",
@@ -521,6 +533,7 @@
 			"version": "3.972.49",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
 			"integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -537,6 +550,7 @@
 			"version": "3.972.55",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
 			"integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -555,6 +569,7 @@
 			"version": "3.972.55",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
 			"integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -742,6 +757,7 @@
 			"version": "3.997.23",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
 			"integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -763,6 +779,7 @@
 			"version": "3.996.35",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
 			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.13",
@@ -778,6 +795,7 @@
 			"version": "3.1074.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
 			"integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.23",
@@ -795,6 +813,7 @@
 			"version": "3.973.13",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
 			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.3",
@@ -824,6 +843,7 @@
 			"version": "3.965.8",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
 			"integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -836,6 +856,7 @@
 			"version": "3.972.31",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
 			"integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.3",
@@ -849,6 +870,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
 			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.0.0"
@@ -1009,6 +1031,7 @@
 			"version": "3.26.0",
 			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
 			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
@@ -1023,6 +1046,7 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
 			"integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.26.0",
@@ -1037,6 +1061,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
 			"integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.26.0",
@@ -1051,6 +1076,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1063,6 +1089,7 @@
 			"version": "4.8.2",
 			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
 			"integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.26.0",
@@ -1077,6 +1104,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
 			"integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.26.0",
@@ -1091,6 +1119,7 @@
 			"version": "4.15.0",
 			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
 			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -1103,6 +1132,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
@@ -1116,6 +1146,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
@@ -1403,6 +1434,7 @@
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
 			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -2790,9 +2822,9 @@
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
 		},
 		"node_modules/leo-aws": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/leo-aws/-/leo-aws-4.0.1.tgz",
-			"integrity": "sha512-ffkCXjAoBdKpF8NJxiiIcAGCrEfBomtevY3LC6/f867TGnCFLyB4/XRI1FvxeXws/i7gIHrzoabpQiT9wKnF/w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/leo-aws/-/leo-aws-2.0.3.tgz",
+			"integrity": "sha512-Q6ghY/j6pWmX6NL6ODm7Cy+zx5HGxezrUSp7wtmFZGK3JHGN0vwboJMlZSVu6WIGBtgb2xmGghRqP+Ga4JB9tA==",
 			"license": "MIT",
 			"dependencies": {
 				"async": "^2.6.1",
@@ -2804,15 +2836,7 @@
 				"lodash.merge": "^4.6.2"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-cloudformation": "^3.470.0",
-				"@aws-sdk/client-dynamodb": "^3.449.0",
-				"@aws-sdk/client-kms": "^3.474.0",
-				"@aws-sdk/client-s3": "^3.445.0",
-				"@aws-sdk/client-secrets-manager": "^3.445.0",
-				"@aws-sdk/client-sqs": "^3.474.0",
-				"@aws-sdk/credential-providers": "^3.474.0",
-				"@aws-sdk/lib-dynamodb": "^3.449.0",
-				"@aws-sdk/node-http-handler": "^3.374.0"
+				"aws-sdk": "^2.581.0"
 			}
 		},
 		"node_modules/leo-config": {
@@ -2824,39 +2848,29 @@
 			}
 		},
 		"node_modules/leo-connector-common": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/leo-connector-common/-/leo-connector-common-5.0.3.tgz",
-			"integrity": "sha512-dKeSEHzbZXe6KJiAv3Wd3alKpaIGR9huFvtOjTrW/ZJsBGx6Fqk65sgIp+RBR3Y6i+7MYlBQQ1IXhi3dTojU/A==",
+			"version": "4.0.13-rc",
+			"resolved": "https://registry.npmjs.org/leo-connector-common/-/leo-connector-common-4.0.13-rc.tgz",
+			"integrity": "sha512-RXBVMTBOY7oc9EdFCHYxg4GePeKTvhwsgbsohNJ3hpw9ognHkdX3rqsrnhcjXeJEt/BS9/f3jZt4Ra4dk+SdXQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@aws-sdk/client-lambda": "^3.489.0",
-				"async": "2.6.4",
-				"leo-aws": "^4.0.0",
-				"leo-logger": "1.0.7",
+				"async": "2.6.3",
+				"leo-aws": "^2.0.3",
+				"leo-logger": "1.0.1",
 				"leo-streams": "2.0.0",
-				"moment": "2.30.1",
+				"moment": "2.24.0",
 				"sqlstring": "2.3.1"
 			},
 			"peerDependencies": {
-				"leo-sdk": ">=7.1.0"
+				"leo-sdk": ">=5.0.27-latest-v5"
 			}
 		},
-		"node_modules/leo-connector-common/node_modules/async": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+		"node_modules/leo-connector-common/node_modules/moment": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
 			"license": "MIT",
-			"dependencies": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"node_modules/leo-connector-common/node_modules/leo-logger": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/leo-logger/-/leo-logger-1.0.7.tgz",
-			"integrity": "sha512-/72+KNRJfde5PqYXi6RvcT+SUXnsVFLrNzkKoqVBPekNTd332Hf27J5iUzcOr1Oji2bHmD2edKeBq4GKlCk2Ww==",
-			"license": "MIT",
-			"dependencies": {
-				"lodash": "^4.17.21"
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/leo-logger": {

--- a/datalake/package.json
+++ b/datalake/package.json
@@ -29,7 +29,7 @@
 		"generic-pool": "^3.9.0",
 		"farmhash-modern": "^1.1.0",
 		"fast-csv": "2.4.1",
-		"leo-connector-common": "5.0.3",
+		"leo-connector-common": "4.0.13-rc",
 		"leo-logger": "1.0.1",
 		"leo-sdk": "7.1.12",
 		"leo-streams": "2.0.0",


### PR DESCRIPTION
## Summary

- Reverts `leo-connector-common` from `5.0.3` → `4.0.13-rc`
- `5.0.3` was released from an unofficial `awsv3` branch and is not ready for production use
- `4.0.13-rc` satisfies the `leo-sdk@7.1.12` peer dep range (`>=5.0.27-latest-v5`) so the leo7 upgrade still holds
- `aws-sdk` v2 is not re-added as a direct dep — the connector never exercises the `leo-aws` code paths in `leo-connector-common`, confirmed by integration tests passing without it (consistent with `leo-connector-postgres` which also does not declare it)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 208 unit tests passing
- [x] `npm run test:int-local` — 23 integration tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Downgrading a shared data-warehouse connector library can change offload/transform behavior at runtime even without local code edits; mitigated by stated unit/integration test passes but still warrants regression awareness in production bots.
> 
> **Overview**
> **Pins `leo-connector-common` back to `4.0.13-rc`** in `datalake/package.json` (from `5.0.3`) and refreshes `package-lock.json` so the datalake connector no longer pulls the unofficial `5.x` / AWS SDK v3-oriented stack.
> 
> The lockfile shift is mostly transitive: **`leo-aws` drops from `4.0.1` to `2.0.3`** (v2 `aws-sdk` peer instead of v3 clients), **`moment` on the common package goes to `2.24.0`**, and nested duplicate deps under common are removed. **`aws-sdk` v2 is not added** as a direct datalake dependency.
> 
> No connector source changes—dependency-only revert while keeping **`leo-sdk@7.1.12`** and existing AWS SDK v3 packages in **devDependencies** for tests/tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25357b40c9a9bb95f3957db172e973199abab53b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->