### PR TITLE
fix(datalake): remove hardcoded dev-cup default from integration test config

### DIFF
--- a/datalake/CLAUDE.md
+++ b/datalake/CLAUDE.md
@@ -164,7 +164,7 @@ The shared audit-timestamp helper [`lib/audit_timestamp.js`](lib/audit_timestamp
 Run in this order; all must pass before considering work complete:
 1. `npm run lint` — eslint
 2. `npm test` — mocha unit tests
-3. `npm run test:int-local` — integration tests against the dev Databricks workspace (requires `~/.databrickscfg [dev-cup]`); uses the `public_stage_local` isolation schema via `LEO_LOCAL=true`
+3. `npm run test:int-local` — integration tests against the dev Databricks workspace (requires `DATABRICKS_CONFIG_PROFILE` pointing to a `~/.databrickscfg` section with `host` + auth, or equivalent env vars); uses the `public_stage_local` isolation schema via `LEO_LOCAL=true`
 
 Note: this connector is plain JavaScript (matches all siblings in `connectors/`). There is no TypeScript compilation step.
 

--- a/datalake/README.md
+++ b/datalake/README.md
@@ -22,7 +22,7 @@ npm run test:int-ci      # CI run — targets public_stage schema
 
 Both scripts hit the same shared dev Databricks workspace (`dbc-0b0acbc9-467a`). The difference is the target schema: `test:int-local` sets `LEO_LOCAL=true` which selects `public_stage_local`; `test:int-ci` uses `public_stage`. Use `test:int-local` for day-to-day local development.
 
-The suite skips silently when credentials aren't configured, so an unconfigured `npm run test:int-local` exits 0 — it's the configured-but-failing case that signals a regression. Set up once per developer:
+The suite **fails (non-zero exit)** when credentials aren't configured — missing credentials are a configuration error, not a skip condition. Set up once per developer:
 
 ### 1. AWS access — already in place for Dsco developers
 
@@ -35,9 +35,9 @@ aws sts get-caller-identity
 # Arn should end in :assumed-role/dsco-aws-poweruser/<you>
 ```
 
-### 2. Databricks `[dev-cup]` profile in `~/.databrickscfg`
+### 2. Databricks credentials in `~/.databrickscfg`
 
-The integration helper parses `~/.databrickscfg` directly and reads the `[dev-cup]` section. The connector uses OAuth M2M (service-principal `client_id` + `client_secret`); a PAT is also supported as a fallback.
+The integration helper reads a named section from `~/.databrickscfg` — you choose the section name and point to it via `DATABRICKS_CONFIG_PROFILE`. The connector uses OAuth M2M (service-principal `client_id` + `client_secret`); a PAT is also supported as a fallback.
 
 **Recommended — fetch the CI service-principal credentials from Secrets Manager, in the Data Emporium Nonprod account (641864320185), not dsco (220162591379):**
 
@@ -50,13 +50,19 @@ aws --profile data-emporium-nonprod secretsmanager get-secret-value \
   --query SecretString --output text
 ```
 
-Then add to `~/.databrickscfg`:
+Then add to `~/.databrickscfg` using whatever section name you prefer (e.g. `my-dev-cup`):
 
 ```ini
-[dev-cup]
+[my-dev-cup]
 host          = https://dbc-0b0acbc9-467a.cloud.databricks.com
 client_id     = <value from CUP_DATABRICKS_CLIENT_ID>
 client_secret = <value from CUP_DATABRICKS_CLIENT_SECRET>
+```
+
+Export the matching env var before running tests:
+
+```sh
+export DATABRICKS_CONFIG_PROFILE=my-dev-cup
 ```
 
 **Alternative — personal access token (PAT):**
@@ -65,10 +71,12 @@ client_secret = <value from CUP_DATABRICKS_CLIENT_SECRET>
 2. Add to `~/.databrickscfg`:
 
 ```ini
-[dev-cup]
+[my-dev-cup]
 host  = https://dbc-0b0acbc9-467a.cloud.databricks.com
 token = <your PAT>
 ```
+
+3. `export DATABRICKS_CONFIG_PROFILE=my-dev-cup`
 
 The connector's auth selection in [`lib/connect.js`](lib/connect.js) prefers `client_id`/`client_secret` (OAuth M2M) when both are present; otherwise it falls back to `token` (PAT). For day-to-day local dev either works; for anything that needs the same identity as the production bot, use the service-principal credentials.
 
@@ -86,7 +94,7 @@ Every locked default in [`test/integration/helpers/databricks.js`](test/integrat
 
 | Env var | Default | Source |
 |---|---|---|
-| `DATABRICKS_CONFIG_PROFILE` | `dev-cup` | which section of `~/.databrickscfg` to read |
+| `DATABRICKS_CONFIG_PROFILE` | *(required)* | which section of `~/.databrickscfg` to read |
 | `DATABRICKS_HOST` | from profile | hostname (with or without `https://`) |
 | `DATABRICKS_HTTP_PATH` | `/sql/1.0/warehouses/5d84579f11466e3f` | SQL warehouse HTTP path |
 | `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET` | from profile | OAuth M2M |
@@ -101,10 +109,10 @@ The host allowlist in [`helpers/databricks.js`](test/integration/helpers/databri
 
 ### Troubleshooting
 
-- **All tests skip with no output** — `[dev-cup]` profile missing or has no `client_id`/`client_secret`/`token`. Helper returns `null`, every test calls `this.skip()`.
-- **`SAFETY: DATABRICKS_HOST … not in nonprod allowlist`** — host doesn't match the allowlist; either you set `DATABRICKS_HOST` to a non-dev workspace, or `[dev-cup]`'s `host` is wrong.
+- **`Integration tests require Databricks credentials…`** — `DATABRICKS_CONFIG_PROFILE` not set, or the named profile section doesn't exist or has no `client_id`/`client_secret`/`token`. Set the env var to your profile section name, or supply `DATABRICKS_HOST` + auth directly as env vars.
+- **`SAFETY: DATABRICKS_HOST … not in nonprod allowlist`** — host doesn't match the allowlist; either you set `DATABRICKS_HOST` to a non-dev workspace, or your profile's `host` is wrong.
 - **`AccessDenied … s3:PutObject`** — your AWS chain isn't resolving to `dsco-aws-poweruser`, or the bucket policy hasn't deployed in your env. `aws sts get-caller-identity` to confirm, then check the [`dsco_cross_account_stack.py`](../../data-lake-infrastructure/src/data_lake/dsco_cross_account_stack.py) deploy status in dev.
-- **`PERMISSION_DENIED … MODIFY` on `ALTER TABLE`** — the SP behind your `[dev-cup]` profile lacks `MODIFY` on `de_cup_dev_us.public_stage_local`. Check Unity Catalog grants.
+- **`PERMISSION_DENIED … MODIFY` on `ALTER TABLE`** — the SP behind your profile lacks `MODIFY` on `de_cup_dev_us.public_stage_local`. Check Unity Catalog grants.
 
 ## Architecture
 

--- a/datalake/test/integration/harness.test.js
+++ b/datalake/test/integration/harness.test.js
@@ -2,7 +2,7 @@
 
 // Step 9 — Integration harness
 // Verifies connectivity, schema accessibility, and staging-location resolution.
-// Skips all tests when ~/.databrickscfg [dev-cup] (or env override) is absent.
+// Throws (fails) when DATABRICKS_CONFIG_PROFILE + ~/.databrickscfg or DATABRICKS_HOST+auth env vars are not configured.
 //
 // Uses fixed schema names (public_stage_local for local dev, public_stage for CI);
 // isolation is per-branch catalog, not per-run UUID schema.

--- a/datalake/test/integration/helpers/databricks.js
+++ b/datalake/test/integration/helpers/databricks.js
@@ -4,7 +4,7 @@
 //
 // Resolution order per field:
 //   1. Environment variable (DATABRICKS_HOST, DATABRICKS_CLIENT_ID, etc.) — explicit override
-//   2. ~/.databrickscfg [<profile>] — default `dev-cup`, override via DATABRICKS_CONFIG_PROFILE
+//   2. ~/.databrickscfg [<profile>] — section named by DATABRICKS_CONFIG_PROFILE (no default; must be set explicitly)
 //   3. Per-workspace defaults auto-selected by host (see DEFAULTS_BY_HOST below)
 //
 // LEO_LOCAL=true (test:int-local) selects the `public_stage_local` schema; omitting it
@@ -12,9 +12,13 @@
 // Databricks workspace. Follows the same leo-config convention bots use.
 // Individual env vars still override any field.
 //
-// If neither env nor profile yields host + auth (token OR client_id/client_secret),
+// If neither env vars nor a named profile yields host + auth (token OR client_id/client_secret),
 // `getConfig()` throws — running the integration suite without credentials is a
 // configuration error, not a skip condition.
+//
+// Set DATABRICKS_CONFIG_PROFILE to the section name in ~/.databrickscfg that holds your
+// credentials, or supply DATABRICKS_HOST + DATABRICKS_TOKEN (or CLIENT_ID+SECRET) directly
+// as env vars. There is no default profile name — it must be configured explicitly.
 //
 // AWS credentials for S3 staging come from the standard chain (~/.aws, SSO, env).
 // Cross-account write to the DE bucket is granted by the bucket policy attached in
@@ -31,8 +35,6 @@ if (!process.env.Resources) {
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-
-const DEFAULT_PROFILE = 'dev-cup';
 
 // Per-environment defaults keyed by host fragment.
 // s3Prefix follows build_plan.md §6: per-schema under `stage/data/internal/rithum/`.
@@ -108,8 +110,8 @@ function stripScheme(host) {
 }
 
 function getConfig() {
-	const profileName = process.env.DATABRICKS_CONFIG_PROFILE || DEFAULT_PROFILE;
-	const profile = loadProfile(profileName) || {};
+	const profileName = process.env.DATABRICKS_CONFIG_PROFILE;
+	const profile = profileName ? (loadProfile(profileName) || {}) : {};
 
 	const host = stripScheme(process.env.DATABRICKS_HOST || profile.host);
 	const token = process.env.DATABRICKS_TOKEN || profile.token;
@@ -118,11 +120,14 @@ function getConfig() {
 
 	const hasAuth = !!(token || (clientId && clientSecret));
 	if (!host || !hasAuth) {
-		const profileNote = `profile [${profileName}] in ~/.databrickscfg`;
 		const missing = !host ? 'host' : 'auth (token or client_id+client_secret)';
+		const profileHint = profileName
+			? `profile [${profileName}] in ~/.databrickscfg or `
+			: '';
 		throw new Error(
-			`Integration tests require Databricks credentials — ${missing} not found in ${profileNote} or env vars. ` +
-			`Set up ~/.databrickscfg [${profileName}] or set DATABRICKS_HOST / DATABRICKS_TOKEN / DATABRICKS_CLIENT_ID+SECRET.`
+			`Integration tests require Databricks credentials — ${missing} not found in ${profileHint}env vars. ` +
+			`Set DATABRICKS_CONFIG_PROFILE to a ~/.databrickscfg section name, or supply ` +
+			`DATABRICKS_HOST / DATABRICKS_TOKEN / DATABRICKS_CLIENT_ID+SECRET directly.`
 		);
 	}
 

--- a/datalake/test/integration/round_trip.test.js
+++ b/datalake/test/integration/round_trip.test.js
@@ -6,7 +6,7 @@
 //   - sampled rows match input values
 //   - surrogate keys match Node-side fingerprint64 recomputation
 //
-// Skips when ~/.databrickscfg [dev-cup] (or env override) is unavailable.
+// Throws (fails) when DATABRICKS_CONFIG_PROFILE + ~/.databrickscfg or DATABRICKS_HOST+auth env vars are not configured.
 
 const { Readable } = require('stream');
 const { expect } = require('chai');

--- a/datalake/test/integration/session_reuse.test.js
+++ b/datalake/test/integration/session_reuse.test.js
@@ -11,7 +11,7 @@
 //      next query on the same client succeeds (session was released, not destroyed).
 //   4. end() completes cleanly — no hang after normal queries finish.
 //
-// Skips when ~/.databrickscfg [dev-cup] (or env override) is unavailable.
+// Throws (fails) when DATABRICKS_CONFIG_PROFILE + ~/.databrickscfg or DATABRICKS_HOST+auth env vars are not configured.
 
 const { expect } = require('chai');
 const { getConfig, checkAllowedHost } = require('./helpers/databricks.js');

--- a/datalake/test/integration/statement_timeout_repro.sh
+++ b/datalake/test/integration/statement_timeout_repro.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-PROFILE="${DATABRICKS_CONFIG_PROFILE:-dev-cup}"
+PROFILE="${DATABRICKS_CONFIG_PROFILE:?DATABRICKS_CONFIG_PROFILE is required (set to your ~/.databrickscfg section name)}"
 WAREHOUSE_ID="${WAREHOUSE_ID:-5d84579f11466e3f}"
 DBC="databricks --profile $PROFILE"
 

--- a/datalake/test/integration/timezone.test.js
+++ b/datalake/test/integration/timezone.test.js
@@ -11,7 +11,7 @@
 //   - Round-trip parity across canonical timestamp shapes
 //   - DST boundary cases — wall-clock preserved, no DST awareness in NTZ
 //
-// Skips when ~/.databrickscfg [dev-cup] (or env override) is unavailable.
+// Throws (fails) when DATABRICKS_CONFIG_PROFILE + ~/.databrickscfg or DATABRICKS_HOST+auth env vars are not configured.
 
 const { Readable } = require('stream');
 const { expect } = require('chai');


### PR DESCRIPTION
DPLAT-466

DATABRICKS_CONFIG_PROFILE is now required — there is no default profile name. getConfig() throws when host+auth are missing (fail-fast, not skip). Updated test file comments, README, CLAUDE.md, and statement_timeout_repro.sh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and developer-docs configuration only; no connector runtime or data-path behavior changes.
> 
> **Overview**
> Removes the hardcoded **`dev-cup`** default from the integration test config helper so **`DATABRICKS_CONFIG_PROFILE`** must name a `~/.databrickscfg` section (or developers supply **`DATABRICKS_HOST`** plus auth via env). **`getConfig()`** error text is updated to match; **`statement_timeout_repro.sh`** now fails fast if the profile env var is unset.
> 
> Docs (**`README.md`**, **`CLAUDE.md`**) and integration test file headers are aligned with current behavior: missing credentials are a **configuration error** (suite throws / exits non-zero), not a silent skip. Setup examples use a developer-chosen profile name (e.g. **`my-dev-cup`**) with **`export DATABRICKS_CONFIG_PROFILE=...`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd6e09c03956c20318b731d9a729b31b32210fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->