### PR TITLE
fix(combine): preserve insert data on same-batch create+delete (RPL-6000)

### DIFF
--- a/common/datawarehouse/combine-records.js
+++ b/common/datawarehouse/combine-records.js
@@ -1,0 +1,45 @@
+const merge = require("lodash/merge");
+
+/**
+ * Collapse two records that share the same natural key.
+ *
+ * Records for one key reach this function in arrival order (combine sorts by
+ * natural-key hash then by an arrival counter first), so `data` always arrived
+ * after `lastObj`.
+ *
+ * The last event for a key in the batch wins the active-vs-deleted decision, and
+ * data is preserved so neither outcome is a bare/sparse row:
+ *
+ *   - insert/update then delete -> the delete wins, but the accumulated data is kept,
+ *     so the row is created-then-soft-closed rather than written as a bare tombstone.
+ *     (Previously the insert's data was discarded and a sparse row written — RPL-5795.)
+ *   - delete then insert/update -> the later write wins and REACTIVATES the entity; the
+ *     delete intent is dropped. Loading data after a delete undeletes the row, per
+ *     ES-2516 ("clear the deleted flag when loading data" — facts set `_deleted = false`
+ *     on load; the merge layer applies it).
+ *   - lone / leading delete with no data -> stays a bare tombstone (an ordinary
+ *     cross-batch delete of a row that already exists in the target) — unchanged.
+ *   - two writes, no delete -> deep-merged — unchanged behavior.
+ *
+ * @param {object} lastObj the earlier record (accumulator)
+ * @param {object} data the later record
+ * @returns {object} the collapsed record
+ */
+function combineRecords(lastObj, data) {
+	if (data.__leo_delete__) {
+		// Later event is a delete: it wins. Stamp the delete markers onto whatever has
+		// been accumulated, preserving any data columns so the closed row is populated
+		// rather than a bare tombstone.
+		lastObj.__leo_delete__ = data.__leo_delete__;
+		lastObj.__leo_delete_id__ = data.__leo_delete_id__;
+		return lastObj;
+	}
+	if (lastObj.__leo_delete__) {
+		// Earlier event was a delete, later event is a write: the write wins and
+		// reactivates the entity (ES-2516). Drop the delete and keep the later record.
+		return data;
+	}
+	return merge(lastObj, data);
+}
+
+module.exports = combineRecords;

--- a/common/datawarehouse/combine.js
+++ b/common/datawarehouse/combine.js
@@ -1,11 +1,11 @@
 const exec = require('child_process').exec;
 const fs = require("fs");
 const path = require("path");
-const merge = require("lodash/merge");
 const PassThrough = require("stream").PassThrough;
 const leo = require("leo-sdk");
 const ls = leo.streams;
 const transform = require("./transform.js");
+const combineRecords = require("./combine-records.js");
 const async = require("async");
 const crypto = require("crypto");
 
@@ -118,14 +118,10 @@ function combine(file) {
 				process.exit();
 			}
 			if (lastObj && id === lastId) {
-				if (data.__leo_delete__ || lastObj.__leo_delete__) {
-					// if our current row is a delete, then we throw away the previous updates
-					// if our previous row was a delete, but the current one is not, we throw away the delete, because it was updated
-					// after the delete, so it should NOT be deleted.
-					lastObj = data;
-				} else {
-					lastObj = merge(lastObj, data);
-				}
+				// Collapse same-natural-key records in arrival order. A delete is a
+				// soft close, so the row's data must survive the collapse — see
+				// combine-records.js (RPL-5795).
+				lastObj = combineRecords(lastObj, data);
 			} else {
 				if (lastObj) {
 					push(lastObj);

--- a/common/test/datawarehouse/combine.test.js
+++ b/common/test/datawarehouse/combine.test.js
@@ -1,0 +1,73 @@
+const { expect } = require("chai");
+const combineRecords = require("../../datawarehouse/combine-records.js");
+
+// Mirror how the combine stream folds records for a single natural key: they
+// arrive already sorted (natural-key hash, then arrival order) and are folded
+// left via combineRecords, starting from the first record of the key group.
+function collapse(records) {
+	return records.reduce((lastObj, data, i) => (i === 0 ? data : combineRecords(lastObj, data)));
+}
+
+// A dimension insert/update record (natural key `id`), plus optional overrides.
+const insert = (over = {}) => Object.assign({ id: "abc", status: "open", amount: 10 }, over);
+
+// A delete marker as stamped by load.js checkforDelete. Deleting by the primary
+// `id` keeps the real id (so it collapses onto the insert); deleting by another
+// field uses a synthetic `_del_<id>` id (so it never collapses onto an insert).
+const del = (field = "id", id = "abc") => ({
+	id: field === "id" ? id : `_del_${id}`,
+	__leo_delete__: field,
+	__leo_delete_id__: id,
+});
+
+describe("combine collapse (same-batch soft-delete ordering)", () => {
+	it("insert then delete: keeps the insert data and carries the delete intent (create-then-close)", () => {
+		const out = collapse([insert(), del()]);
+		expect(out.__leo_delete__).to.equal("id");
+		expect(out.__leo_delete_id__).to.equal("abc");
+		expect(out.status).to.equal("open"); // data must NOT be discarded (was RPL-5795)
+		expect(out.amount).to.equal(10);
+		expect(out.id).to.equal("abc");
+	});
+
+	it("insert, update, then delete: merges the data, then carries the delete intent", () => {
+		const out = collapse([insert(), insert({ amount: 25, note: "x" }), del()]);
+		expect(out.__leo_delete__).to.equal("id");
+		expect(out.amount).to.equal(25); // later update won
+		expect(out.note).to.equal("x");
+		expect(out.status).to.equal("open");
+	});
+
+	it("delete then insert: the later write reactivates (delete dropped), data present — ES-2516", () => {
+		const out = collapse([del(), insert({ amount: 99 })]);
+		expect(out.__leo_delete__).to.equal(undefined); // reactivated: no delete intent
+		expect(out.status).to.equal("open");
+		expect(out.amount).to.equal(99);
+	});
+
+	it("insert, delete, then insert: ends as a fresh active row (last event is a write) — ES-2516", () => {
+		const out = collapse([insert(), del(), insert({ amount: 7 })]);
+		expect(out.__leo_delete__).to.equal(undefined); // last event wins → active
+		expect(out.amount).to.equal(7);
+	});
+
+	it("insert then two deletes: still keeps data + delete intent (not a bare tombstone)", () => {
+		const out = collapse([insert(), del(), del()]);
+		expect(out.__leo_delete__).to.equal("id");
+		expect(out.status).to.equal("open");
+	});
+
+	it("leading/lone delete stays a bare tombstone (ordinary cross-batch delete)", () => {
+		const out = collapse([del(), del()]);
+		expect(out.__leo_delete__).to.equal("id");
+		expect(out.status).to.equal(undefined);
+		expect(out.amount).to.equal(undefined);
+	});
+
+	it("two data rows without a delete: deep-merged (unchanged behavior)", () => {
+		const out = collapse([insert({ a: { x: 1 } }), insert({ a: { y: 2 }, amount: 50 })]);
+		expect(out.__leo_delete__).to.equal(undefined);
+		expect(out.a).to.deep.equal({ x: 1, y: 2 }); // deep merge preserved
+		expect(out.amount).to.equal(50);
+	});
+});


### PR DESCRIPTION
## Problem

A dimension/fact delete in this connector is a **soft close**, so it needs the target row to exist. When an entity is **created and then deleted within one `combine` batch**, the collapse in `common/datawarehouse/combine.js` discarded the insert's data (`lastObj = data`), leaving a bare tombstone that the loader wrote as a **sparse row** (data columns null, date/dimension FKs = `1`, never closed). Verified in production — **596 rows** in `de_cup_prod_us.public.d_invoice`. Tracked as **RPL-6000**.

## Fix

Collapse same-key records with **last-event-wins** ordering, but never discard data. The decision is extracted into a pure module `common/datawarehouse/combine-records.js`:

- insert/update → delete: the delete wins, its markers stamped onto the accumulated record → created-then-soft-closed, not a bare tombstone.
- delete → insert/update: the later write wins and **reactivates** the entity (ES-2516, "clear the deleted flag when loading data").
- two writes: deep-merge (unchanged). lone/leading delete: unchanged bare tombstone.

The extraction lets the collapse be unit-tested without importing `combine.js` (which pulls in `leo-sdk`/`aws-sdk`). `combine.js` now calls the helper; behavior is otherwise identical.

## Behavior

| Same-batch sequence (arrival order) | Before | After |
|---|---|---|
| insert, delete | bare sparse tombstone (data lost) | populated + soft-closed |
| delete, insert | reactivated (write wins) | reactivated (unchanged) |
| insert, update | deep-merged | deep-merged (unchanged) |
| lone delete | bare tombstone | bare tombstone (unchanged) |

## Tests

Adds `common/test/datawarehouse/combine.test.js` — 7 cases across every collapse path (there was no `combine` coverage before). `npm test` in `common/` and `eslint` on the changed files are green.

## Scope / rollout

- Shared `leo-connector-common`; consumers pin an exact version, so this reaches a connector only when it bumps its pin — nothing floats in automatically.
- **First consumer:** the datalake connector — its `importDimension` companion is Chub-Engineering/rstreams-connector-datalake#33. Together they fully close **RPL-6000**.
- **Redshift/postgres path unaffected** until `general` bumps its pin; the same defect is latent there (short read window) and tracked as **RPL-5796** (mirror fix: run the soft-close flush *after* the insert).

Refs: RPL-6000, RPL-5796, ES-2516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
